### PR TITLE
Revert "specifications: Fix image links"

### DIFF
--- a/specification/attestation.adoc
+++ b/specification/attestation.adoc
@@ -39,7 +39,7 @@ consider that Attester a trustworthy peer or not. The Verifier appraises
 evidence via appraisal policies and creates the Attestation Results to 
 support Relying Parties in their decision process.
 
-image:images/img_4.png[]
+image:img_4.png[]
 Figure 4: Remote Attestation Framework (IETF RATS)
 
 This TEE proposal uses the layered attestation model <<R1>> where the RoT 
@@ -65,7 +65,7 @@ chain.
 The TCB extension and evidence collection for a TVM attestation is shown 
 below:
 
-image:images/img_5.png[]
+image:img_5.png[]
 Figure 5: Layered Attestation architecture for TVMs
 
 It is expected that an implementation will provide implementation-specific 
@@ -191,7 +191,7 @@ As a tangible example, the CDI private key for the TSM were used to sign a
 leaf certificate for an attestation key for the TVM, the certificate chain 
 may look like this:
 
-image:images/img_6.png[]
+image:img_6.png[]
 Figure 6: Attestation Certificate generation
 
 This attestation certificate can be used in a challenge/response protocol 

--- a/specification/overview.adoc
+++ b/specification/overview.adoc
@@ -11,7 +11,7 @@ the OS or VMM to maintain the role of resource manager even for the TVMs. The
 resources managed by the untrusted OS/VMM include memory, CPU, I/O resources 
 and platform capabilities to execute the TVM workload.
 
-image:images/img_0.png[Figure 1]
+image:img_0.png[Figure 1]
 Figure 1: TEE TCB for VM workloads
 
 As shown in figure 1, the architecture comprises a HS-mode software module 
@@ -88,7 +88,7 @@ modes of operation are also possible as TEE workloads. Importantly, the HW
 mechanisms needed for both cases are identical, and can be supported with 
 appropriate extensions of the TG-ABI.
 
-image:images/img_1.png[]
+image:img_1.png[]
 Figure 2: TEE TCB for application workloads (hosted via a TVM)
 
 The detailed architecture is described in the Section 

--- a/specification/refarch.adoc
+++ b/specification/refarch.adoc
@@ -120,7 +120,7 @@ different hart). This model of TSM operation requires additional
 concurrency controls on internal data structures and per-TVM global data 
 structures (such as the second stage page table structures).
 
-image:images/img_3.png[]  
+image:img_3.png[]  
 Figure 3: TSM operation - Interruptible and non-reentrant TSM model shown.
 
 A TSM entry triggered by an ECALL (with AP-TEE service type) by the OS/VMM 


### PR DESCRIPTION
Reverts riscv-non-isa/riscv-ap-tee#1

Cleaner way to insert image path is via ":imagesdir: ./images" so that both the make and the individual adoc renders fine.