### PR TITLE
Add gem mathematical.so build dependencies in 22.04

### DIFF
--- a/dependencies/apt_packages.txt
+++ b/dependencies/apt_packages.txt
@@ -13,6 +13,8 @@ libffi-dev
 libgdk-pixbuf2.0-dev
 libpango1.0-dev
 libxml2-dev
+libwebp-dev
+libzstd-dev
 make
 pkg-config
 ruby


### PR DESCRIPTION
Signed-off-by: Jeff Scheel <jeff@riscv.org>