### PR TITLE
Node migration 2 of 2

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -66,24 +66,11 @@ jobs:
         path: ./specification/riscv-aptee-spec.pdf
         retention-days: 7
     - name: Create Release
-      id: create_release
-      if: ${{ github.event.inputs.prerelease }}
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
+        files: ./specification/riscv-aptee-spec.pdf
         tag_name: ${{ github.ref_name }}
-        release_name: Release ${{ github.ref_name }}
+        name: Release ${{ github.ref_name }}
         draft: false
         prerelease: true
-    - name: Upload Release Asset
-      id: upload-release-asset
-      if: ${{ github.event.inputs.prerelease }}
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./specification/riscv-aptee-spec.pdf
-        asset_name: riscv-aptee-spec.pdf
-        asset_content_type: application/pdf
+


### PR DESCRIPTION
Substitute softprops/action-gh-release for read-only actions create-release and upload-release-assets to fix Node 12 deprecation warnings.

Signed-off-by: Jeff Scheel <jeff@riscv.org>