### PR TITLE
gha: Bump Ruby to 3.1

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Setup Ruby and Gemfile content
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.6"
+        ruby-version: "3.1"
         bundler-cache: true
     # Node.js for wavedrom
     - uses: actions/cache@v3


### PR DESCRIPTION
ascii-doctor new 2.3.6 release uses the absolute_path? method that's only available with Ruby 3.x.

Without this commit, the riscv-ap-tee CI fails with:

converter.rb:4290:in `resolve_image_path': undefined method `absolute_path?' for File:Class (NoMethodError)