### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/refarch.adoc
+++ b/src/refarch.adoc
@@ -334,8 +334,7 @@ concurrency controls on internal data structures and per-TVM global data
 structures (such as the G-stage page table structures).
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
-[title= "TSM operation: Interruptible and non-reentrant TSM model according to
-the deployment model 1."]
+[title= "TSM operation: Interruptible and non-reentrant TSM model according to the deployment model 1."]
 image::img_3.png[]
 
 A TSM entry triggered by an ECALL (with CoVE extension type) by the OS/VMM
@@ -605,3 +604,4 @@ OS/VMM, the TSM must restore the saved hardware performance monitoring event
 triggers and counter enables. If the TSM uses the SBI PMU extension instead of
 Supervisor counter delegation, the TSM-driver needs to perform the save/restore
 on behalf of the TSM.
+

--- a/src/swlifecycle.adoc
+++ b/src/swlifecycle.adoc
@@ -50,8 +50,8 @@ When a TVM context is created and initialized by using the
 `sbi_covh_create_tvm()` function - this global init function allocates a
 set of pages for the TVM global control structure and resets the control
 fields that are immutable for the lifetime of the TVM, e.g., configuration of
-which RISC-V CPU extensions the TVM is allowed to use, debug and pmon
-capabilities enabled etc.
+which RISC-V CPU extensions the TVM is allowed to use, debug and performance
+monitoring capabilities enabled etc.
 
 The VMM may assign memory to the TVM via a sequence of
 `sbi_covh_add_tvm_page_table_pages()` `sbi_covh_add_tvm_measured_pages()` and

--- a/src/threatmodel.adoc
+++ b/src/threatmodel.adoc
@@ -159,7 +159,7 @@ encrypted TEE memory | Supervisor Domains
 Cryptography and/or MMU, xPMP, MTT extension | TEE memory confidentiality
 against logical attacks via hart; additionally address physical attacks via
 cryptography. If cryptography used, TEE should have a unique encryption key;
-each TEE VM may may also have one or more unique keys. Also see related
+each TEE VM may also have one or more unique keys. Also see related
 requirements around ciphertext disclosure and memory integrity  |
 Supervisor Domains
 


### PR DESCRIPTION
1. Fix showing img_3.png in refarch.adoc
2. Remove ":imagesdir: ./images" in the end of refarch.adoc
3. Replace "pmon" with "performance monitoring" in swlifecycle.adoc
4. Remove redundant "may" in threatmodel.adoc