### PR TITLE
Simplify the promote call

### DIFF
--- a/src/appendix_d.adoc
+++ b/src/appendix_d.adoc
@@ -3,138 +3,101 @@
 [[appendix_d]]
 == Appendix D: M-mode TSM based deployment model
 
-This deployment model targets high-assurance systems whose design might be
-constrained
-by real-time and formal verification requirements. It trade offs a feature-rich
-design supporting
-dynamic resource allocation, for simpler implementation, where the correctness
-can be formally verified.
+This deployment model targets systems whose design is constrained by real-time
+requirements, formal verification objectives, or must operate on hardware with
+limited capabilities due to power or silicon constrains.
+It augments a feature-rich architecture with flexible ABI and dynamic resource
+management. We defined a simplified implementation that facilitates safety and
+security verification.
+Typical examples of these systems include high-end embedded or edge systems
+operating on less complex hardware than cloud-grade servers, and high-assurance
+platforms where reduced architectural complexity simplifies formal verification
+of properties such as correctness and isolation.
 
 [id=dep3]
 [caption="Figure {counter:image}"]
-[title= ": M-mode TSM based deployment model for CoVE"]
+[title= ": M-mode TSM based deployment model for CoVE."]
 image::img_11.png[align=center]
 
 === Overview
 <<dep3>> shows that the deployment model supports a single confidential
-supervisor domain in which
-the TSM runs along with the TSM driver in the M-mode. This single confidential
-supervisor domain can run multiple
-TVMs that are isolated from each other using the MMU, i.e., G-stage page tables
-managed by TSM. TSM isolates the
-hosting supervisor domain (i.e., OS/VMM and non-confidential applications and
-VMs) from the confidential supervisor
-domain (TSM and TVMs) using a hardware memory isolation mechanism, like PMP.
-The Supervisor Domain Access Protection (Smmtt) extension is therefore not
-required in this model but not precluded.
-IO accesses to confidential memory must be prevented, for example, with IOPMP.
+supervisor domain in which the TSM runs along with the TSM driver in the M-mode.
+This single confidential supervisor domain can host multiple TVMs. The TSM
+enforces isolation of TVMs using G-stage page tables. It also isolates the
+hosting supervisor domain (i.e., OS/VMM and any non-confidential applications
+and VMs) from the confidential supervisor domain (TVMs) through a hardware memory
+isolation mechanism, such as PMP. In this model, the supervisor domain access
+protection (Smmtt) extension is not required, though its use is not precluded.
+Accesses from I/O to confidential memory must be prevented, for example, though
+the use of IOPMP.
 
 [NOTE]
 ====
 Since the TSM is not required to run in the HS-mode, this deployment model
-supports systems that emulate the
-hypervisor extension or run TVMs and OS/VMM in S-mode. The latter requires use
-of a hardware memory isolation mechanism
-that enforces memory accesses to confidential memory while being only
-controlled by the TSM, e.g., PMP.
+supports systems that emulate the hypervisor extension or run TVMs and OS/VMM in
+S-mode. The latter requires use of a hardware memory isolation mechanism that
+enforces memory accesses to confidential memory while being only controlled by
+the TSM, e.g., PMP.
 ====
 
-=== Static memory partitioning
-The deployment model proposes static partitioning of memory into confidential
-and non-confidential to simplify
-formal reasoning about the correctness of the TVM execution and isolation. TSM
-performs this paritioning early
-during the boot of the platform, resulting in the following advantages: (1)
-simplified formal reasoning about the
-ownership of memory, (2) attestation that covers static system configuration
-(e.g., values of PMP registers),
-(3) reduced attack surface between OS/VMM and TSM due to narrower ABI. A
-possible negative consequence of
-static partitioning is underutilization of resources. Specifically,
-confidential memory created at platform
-initialization might be larger than the required amount of memory utilized by
-TVMs and the TSM during runtime.
-Lack of the conversion mechanism of confidential memory pages to
-non-confidential memory (enabled for example by Smmtt)
-prevents the hosting supervisor domain (OS/VMM, applications, and VMs) from
-using the memory over-provisioned by
-the confidential supervisor domain (TSM, TVMs).
+=== Static Memory Partitioning
+The deployment model should employ a static partitioning of memory into confidential
+and non-confidential regions to simplify formal reasoning about the correctness
+and isolation of TVM execution. The TSM should perform this partitioning early during
+platform boot to gain the following advantages:
+
+. simplified formal reasoning about memory ownership,
+. attestation that covers static system configuration (e.g., values of PMP
+registers),
+. reduced attack surface between OS/VMM and the TSM, achieved through
+preventing the OS/VMM from controlling the allocation of physical
+pages to TVMs and by a narrower ABI.
+
+[NOTE]
+====
+A potential drawback of static partitioning is underutilization of resources.
+Specifically, the amount of confidential memory established during platform
+may exceed the memory required by the TSM and TVMs at runtime.
+In the absence of a mechanism to convert confidential memory pages to
+non-confidential memory (as could be enabled by the Smmtt extension), the
+hosting supervisor domain (i.e., the OS/VMM, applications, and VMs) cannot
+reclaim or use memory over-provisioned to the confidential supervisor domain.
+====
 
 === TVM creation
-To reduce the complexity of the TSM implementation, the TSM creates a TVM as a
-result of a single operation triggered with
-the `sbi_covh_promote_to_tvm()` call. Specifically, OS/VMM initializes and
-starts a regular VM, which early during the
-boot process requests to be promoted to a TVM. This call traps in the OS/VMM
-and is reflected to the TSM, which copies
-VM's data, the page table configuration, and the vCPU state into confidential
-memory. If the request fails, the promotion
-of a VM to a TVM fails and error is returned to the VM. When the request
-succeeds, OS/VMM marks the VM as a TVM,
-so that it can then properly resume its execution via TSM.
+To reduce the complexity of the TSM implementation and its ABI, in this
+deployment model the TSM should create a TVM as a result of a single operation
+triggered with the sbi_covh_promote_to_tvm() call. Specifically, OS/VMM should
+constructs a regular VM in non-confidential memory and requests the TSM to
+promote it to a TVM. To do so, the TSM must copy the VM's data, page tables, and
+the boot vCPU state into confidential memory. When the request succeeds, OS/VMM
+marks the VM as a TVM, so that it can then properly resume its execution via the
+TSM.
 
-=== Local attestation
-Embedded systems might operate without access to a network, which prevents use
-of remote attestation. For this
-reason, this deployment model also supports local attestation, in which the TSM
-attests to the integrity of the TVM image
-during its creation and allows its creation only when it contains a specfic
-`TVM attestation payload` (TAP). This
-payload carries a cryptographic proof issued with the expected attestation key
-specific to the TSM integrity
-and platform configuration. The pointer to TAP is passed in a call to promote a
-VM to a TVM. If it is zero,
-then remote attestation is used, otherwise local attestation is used. Local
-attestation is strongest when it is hardware enforced.
-The TSM must verify that the attestation (i.e., integrity measurements, configuration of the hardware
-platform) of the TVM match the values specified by the TVM creator in the TAP.
+[NOTE]
+====
+The promotion mechanism enables use cases in which a running VM gets
+promoted to a TVM. To support attestation, such promotion must occur when
+the contents of VM's runtime state are predictable, allowing for reliable
+computation of reference integrity measurements. However, certain use cases
+may require promotion after that point and might even exclude some dirty VM pages
+(like those containing custom boot firmware or provisioning code) from the TVM.
+However, if your use case requires promotion after that point, then you must
+exclude dirty VM pages by modifing the FDT to mark selected pages as
+zero pages, and the TSM will clear these pages during promotion.
+====
 
-Local attestation utilizes one or more of the following properties:
-
-. The TSM must be able to verify that a TVM creator authorized the TVM to run on the platform.
-. The TSM enforces that only TVMs created by a trusted partner runs on the hardware.
-
-Separate mechanisms may be used to achieve these goals.
-
-==== TVM Authorization
-The TSM must have a list of public keys of those authorized to sign VMs (TVMs)
-for execution on the platform. The attestation payload associated with the TVM
-will be
-signed with a private key. When the VM is being promoted to a TVM, TSM checks
-the signature inside the TAP.
-If the signature is not valid, the TSM will not convert the VM and will
-terminate execution of the
-VM. The method for provisioning these public keys into the TSM is outside the
-scope of this specification.
-
-==== Verifying Platform configuration
-When the creator of the (authorized) TVM does not want it to execute on
-improperly configured or unauthorized hardware, there should be a mechanism
-supported by hardware (and firmware) for verification.
-Assuming presence of the hardware root-of-trust for measurement and hardware
-root-of-trust for storage, the VM can be created with an encrypted disk and the
-key that is used to decrypt the disk can be sealed to the measurments of the
-platform.
-The creator of the VM using the specifications for the platform decides what
-values are required in order for the key to be released.
-When the request to promote VM to a TVM is called and local attestation is
-successful, the TSM unseals the key with help of the hardware root-of-trust. At
-the point when the TVM needs to decrypt its disk (e.g., for mounting the
-filesystem), the TVM utilizes an ABI call (`sbi_covg_retrieve_secret()`) to
-retrieve the decryption key from the TSM.
-
-=== Further recommendations
-Embedded systems with real-time requirements must have a fixed upper bounded
-execution time. This requires determining
-the maximal number of instructions that can execute between TVM context
-switches. From this reason, this deployment model
-recommends an uninterruptible TSM. <<depd2>> shows this operation mode, in
-which TSM running in M-mode exposes COVH and
-COVG ABI to OS/VMM and TVM, respectively. VM ECALLs trap directly to TSM due to
-the `medeleg` configuration and all
-interrupts during TVM execution trap in TSM due to the `mideleg` configuration.
+=== Further Recommendations
+Embedded systems with real-time requirements must guarantee a fixed upper bound
+on execution time. This necessitates determining the maximum number of
+instructions that may execute between TVM context switches. For this reason,
+this deployment model recommends use of an uninterruptible TSM. <<depd2>>
+illustrates this operating mode, in which the TSM executes in M-mode and exposes
+the COVH and COVG ABIs to the OS/VMM and TVM, respectively. During the TVM
+execution, all exceptions and interrupts trap directly to the TSM, as determined
+by the medeleg and mideleg configurations.
 
 [id=depd2]
 [caption="Figure {counter:image}"]
-[title= ": TSM operation"]
+[title= ": Uninterruptible TSM operation in deployment model 3."]
 image::img_12.png[align=center]

--- a/src/appendix_d.adoc
+++ b/src/appendix_d.adoc
@@ -9,7 +9,7 @@ limited capabilities due to power or silicon constrains.
 It augments a feature-rich architecture with flexible ABI and dynamic resource
 management. We defined a simplified implementation that facilitates safety and
 security verification.
-Typical examples of these systems include high-end embedded or edge systems
+Typical examples of these systems include edge and high-end embedded systems
 operating on less complex hardware than cloud-grade servers, and high-assurance
 platforms where reduced architectural complexity simplifies formal verification
 of properties such as correctness and isolation.
@@ -47,11 +47,11 @@ and isolation of TVM execution. The TSM should perform this partitioning early d
 platform boot to gain the following advantages:
 
 . simplified formal reasoning about memory ownership,
-. attestation that covers static system configuration (e.g., values of PMP
-registers),
 . reduced attack surface between OS/VMM and the TSM, achieved through
 preventing the OS/VMM from controlling the allocation of physical
 pages to TVMs and by a narrower ABI.
+. attestation that covers static system configuration (e.g., values of some
+M-mode registers, like PMP registers),
 
 [NOTE]
 ====
@@ -67,9 +67,9 @@ reclaim or use memory over-provisioned to the confidential supervisor domain.
 === TVM creation
 To reduce the complexity of the TSM implementation and its ABI, in this
 deployment model the TSM should create a TVM as a result of a single operation
-triggered with the sbi_covh_promote_to_tvm() call. Specifically, OS/VMM should
+triggered with the `sbi_covh_promote_to_tvm()` call. Specifically, OS/VMM should
 constructs a regular VM in non-confidential memory and requests the TSM to
-promote it to a TVM. To do so, the TSM must copy the VM's data, page tables, and
+promote it to a TVM. To do so, the TSM must create the VM's data, page tables, and
 the boot vCPU state into confidential memory. When the request succeeds, OS/VMM
 marks the VM as a TVM, so that it can then properly resume its execution via the
 TSM.
@@ -82,9 +82,8 @@ the contents of VM's runtime state are predictable, allowing for reliable
 computation of reference integrity measurements. However, certain use cases
 may require promotion after that point and might even exclude some dirty VM pages
 (like those containing custom boot firmware or provisioning code) from the TVM.
-However, if your use case requires promotion after that point, then you must
-exclude dirty VM pages by modifing the FDT to mark selected pages as
-zero pages, and the TSM will clear these pages during promotion.
+However, if a use case requires promotion after that point, then dirty VM pages
+must be excluded by marking selected pages as zero pages.
 ====
 
 === Further Recommendations

--- a/src/appendix_d.adoc
+++ b/src/appendix_d.adoc
@@ -6,7 +6,7 @@
 This deployment model targets systems whose design is constrained by real-time
 requirements, formal verification objectives, or must operate on hardware with
 limited capabilities due to power or silicon constrains.
-It augments a feature-rich architecture with flexible ABI and dynamic resource
+It augments a feature-rich architecture, which offers flexible ABI and dynamic resource
 management. We defined a simplified implementation that facilitates safety and
 security verification.
 Typical examples of these systems include edge and high-end embedded systems
@@ -44,12 +44,10 @@ the TSM, e.g., PMP.
 The deployment model should employ a static partitioning of memory into confidential
 and non-confidential regions to simplify formal reasoning about the correctness
 and isolation of TVM execution. The TSM should perform this partitioning early during
-platform boot to gain the following advantages:
+platform initialzation to gain the following advantages:
 
 . simplified formal reasoning about memory ownership,
-. reduced attack surface between OS/VMM and the TSM, achieved through
-preventing the OS/VMM from controlling the allocation of physical
-pages to TVMs and by a narrower ABI.
+. reduced attack surface between OS/VMM and the TSM, achieved through a narrower ABI.
 . attestation that covers static system configuration (e.g., values of some
 M-mode registers, like PMP registers),
 
@@ -73,18 +71,6 @@ promote it to a TVM. To do so, the TSM must create the VM's data, page tables, a
 the boot vCPU state into confidential memory. When the request succeeds, OS/VMM
 marks the VM as a TVM, so that it can then properly resume its execution via the
 TSM.
-
-[NOTE]
-====
-The promotion mechanism enables use cases in which a running VM gets
-promoted to a TVM. To support attestation, such promotion must occur when
-the contents of VM's runtime state are predictable, allowing for reliable
-computation of reference integrity measurements. However, certain use cases
-may require promotion after that point and might even exclude some dirty VM pages
-(like those containing custom boot firmware or provisioning code) from the TVM.
-However, if a use case requires promotion after that point, then dirty VM pages
-must be excluded by marking selected pages as zero pages.
-====
 
 === Further Recommendations
 Embedded systems with real-time requirements must guarantee a fixed upper bound

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -94,30 +94,37 @@ the current status of the TSM. The TSM must be in `TSM_READY` in order to
 process further ECALLs.
 
 ===== TVM creation
-A TVM might be created in two ways:
-(1) the OS/VMM requests the TSM to promote an existing VM to a TVM using a
-single COVH call,
-(2) the OS/VMM assembles a TVM under the TSM's supervision in a sequence of
+A TVM might be created in two ways. A CoVE implementation must support at least
+one of them.
+(1) The OS/VMM requests the TSM to promote an existing VM to a TVM using a
+single COVH call.
+(2) The OS/VMM assembles a TVM under the TSM's supervision in a sequence of
 COVH calls.
 
-To promote a non-confidential VM to a TVM, the OS/VMM invokes the
-`sbi_covh_promote_to_tvm()`, presenting the VM's state (the CPU state, VM's
-data, page tables) to the TSM. The TSM then measures and then copies the entire
-VM's state into confidential memory. This is performed as a single operation
-after which the newly created TVM is in the `TVM_RUNNABLE` state.
-
-[NOTE]
-====
-Creating a TVM in a single step reduces the number of ABI calls, thus simplifies
-the TSM and OS/VMM implementation. However, it will block the CPU for the
-duration of the TVM creation.
-====
+In the first approach, the OS/VMM promotes an existing non-confidential VM to a
+TVM by invoking the `sbi_covh_promote_to_tvm()` call. As a response to this call,
+the TSM copies the entire VM's state into confidential memory. This is performed
+as a single operation after which the newly created TVM is in the `TVM_RUNNABLE`
+state.
 
 In the second approach, VMM assembles the TVM in a sequence of calls to TSM. The
 first call is `sbi_covh_create_tvm()` that creates a TVM in `TVM_INITIALIZING`
 state. With subsequent calls to TSM, VMM requests assignment of confidential
 memory for page tables, payload mapping, and vCPUs. The last call transitions
 TVM into the `TVM_RUNNABLE` state.
+
+[NOTE]
+====
+Compared to the multi-step TVM creation, the single step TVM creation minimizes
+the number of ABI calls that the TSM and OS/VMM must implement. The TSM
+remains also responsible for making allocation decisions for G-stage page tables.
+====
+
+[NOTE]
+====
+The single step TVM creation reduces also the number ABI calls invocations, but
+it blocks the CPU for the entire duration of the TVM instantiation.
+====
 
 ===== TVM memory management
 The host is responsible for the following memory management functions:
@@ -1149,11 +1156,12 @@ are deterministic. The VM must not use registers associated with RISC-V
 extensions, e.g., vector, floating point, before promotion, because these
 registers will be zeroized during the promotion.
 
-The TSM recreates TVM vCPUs in confidential memory. All TVM vCPUs are in the
-reset state, except the TVM Boot vCPU, which is the state of the reflected VM's
-vCPU. This VM's vCPU state is reflected using NACL shared memory. The TSM
-recreates in confidential memory the reflected VM's data and the VM's page
-tables, following the page table configuration defined in HGATP.
+The TVM vCPUs are recreated in confidential memory. The TSM reads the number of
+vCPUs from the FDT and sets all TVM vCPUs but the TVM's boot vCPU to reset state.
+The TVM's boot vCPU state is reflected in NACL shared memory and its program
+counter value in the `entry_sepc` call's argument. The TSM recreates in
+confidential memory the reflected VM's data and the VM's page tables, following
+the page table configuration defined in HGATP.
 
 Once the TVM's image is completed, the TSM calculates the TVM measurement.
 If `tap_addr` is defined, the TSM uses this TVM measurement to authenticate and
@@ -2438,7 +2446,7 @@ creation via `sbi_covh_promote_to_tvm()`. Only the TVMs that were correctly
 authenticated and authorized during local attestation can receive the secret
 embedded in TAP.
 
-`buf_addr` is the 4 KiB-aligned address in the TVM address space to which the
+`buf_addr` is the 8B-aligned address in the TVM address space to which the
 TSM will write the secret.
 `buf_size` is the length of the buffer. The buffer cannot be larger than the
 4 KiB page size.
@@ -2806,4 +2814,3 @@ state save and restore of the performance monitoring inhibit and trigger
 controls). The specification of this interface is TBD.
 
 |===
-

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -1146,9 +1146,9 @@ The `tap_addr` is the 8-bytes aligned guest physical address of the
 For VMs that do not require local attestation (only the remote attestation),
 `tap_addr` must be set to `0`.
 The `entry_sepc` is the address at which the vCPU execution will resume.
-`tvm_identity_addr` is an optional, when set, it points to a 64-bytes buffer
-containing a host-defined TVM identity, see `sbi_covh_finalize_tvm()` for more
-details.
+`tvm_identity_addr` is an optional, when set, it points to a 8-byte aligned,
+64-bytes buffer containing a host-defined TVM identity,
+see `sbi_covh_finalize_tvm()` for more details.
 
 The VM should be promoted as early in the boot process as possible to minimize
 changes in memory contents so that the resulting integrity measurement hashes

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -1162,9 +1162,9 @@ See `sbi_covh_finalize_tvm()` for the semantics of the TVM identity.
 Payload (TAP), used for local attestation. For TVMs that require only remote
 attestation, `tap_addr` must be set to `0`.
 
-To promote the VM, the TSM performs the following steps.
+To promote the VM, the TSM performs the following operations.
 
-First, the TSM recreates the VM's page tables and data pages in confidential
+The TSM recreates the VM's page tables and data pages in confidential
 memory, following the page table configuration defined by `hgatp`. For each
 leaf page table entry (PTE), the TSM decodes the page type from bits 8–9
 (the RSW field) as follows:
@@ -1181,11 +1181,11 @@ leaf page table entry (PTE), the TSM decodes the page type from bits 8–9
             Zero pages are not measured.
 |===
 
-Next, the TSM creates `vcpu_count` vCPUs. All vCPUs are initialized to
-architectural reset state. The boot vCPU's `sepc` is set to `entry_sepc`, `a0`
-to the boot hart's identifier, and `a1` to `entry_arg`.
+The TSM creates `vcpu_count` vCPUs. All vCPUs are initialized to
+architectural reset state. The boot vCPU's `[m|s]epc` is set to `entry_sepc`,
+`a0` to the boot hart's identifier (0), and `a1` to `entry_arg`.
 
-Next, the TSM calculates the TVM integrity measurements over the TVM's
+The TSM calculates the TVM integrity measurements over the TVM's
 confidential memory image, including all measured pages and vCPU initial state.
 Both `entry_sepc` and `entry_arg` are included in the measurement. The
 measurement of data pages should already take place in step 1 to avoid
@@ -1194,15 +1194,15 @@ unnecessary memory reads during promotion.
 If `tap_addr` is non-zero, the TSM uses the TVM measurements to authenticate and
 authorize TVM execution as part of the local attestation procedure.
 
-Finally, the TSM sets the TVM state to `TVM_RUNNABLE` and returns a unique TVM
-identifier (`tvm_guest_id`) in `sbiret.value`.
+If the call succeeds, the TSM sets the TVM state to `TVM_RUNNABLE` and returns a
+unique TVM identifier (`tvm_guest_id`) in `sbiret.value`.
 
+[NOTE]
+====
 Note that a TVM created via this call does not require a subsequent call to
-`sbi_covh_finalize_tvm()`.
-Upon successful return, the OS/VMM should release the non-confidential memory
-that contained the VM's data and page tables. Subsequently, the OS/VMM must
-interact with the TVM exclusively via the COVH ABI, resuming vCPU execution via
-`sbi_covh_run_tvm_vcpu()`. The boot vCPU must be run before any other vCPU.
+`sbi_covh_finalize_tvm()` and the OS/VMM must interact with the TVM exclusively
+via the COVH ABI, resuming vCPUs execution via `sbi_covh_run_tvm_vcpu()`.
+====
 
 If the call fails, the TSM returns an error code in `sbiret.error`. The possible
 error codes are shown below.
@@ -1441,6 +1441,8 @@ Adds a vCPU with ID `vcpu_id` to the TVM specified by `tvm_guest_id`.
 region used to hold the TVM's vCPU state, and must be
 `tsm_info::tvm_state_pages` pages in length. This call must not be made after
 calling `sbi_covh_finalize_tvm()`.
+
+The vCPU with ID 0 is designated as the boot vCPU.
 
 The possible error codes returned in `sbiret.error` are shown below.
 

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -300,6 +300,8 @@ interrupt ticking.
                                 to check which interrupts are enabled. This is
                                 useful in waking up a guest's vcpu when it is
                                 sleeping due to a `WFI` instruction.
+| hgatp      |  R    |  W     | Host reflects the address of the page directory
+                                to the TSM during the single-step TVM creation.
 | *GPRs*     |       |        |
 | a0         |  RW   |  RW    | Used for both passing argument and returning
                                 the result for ECALLs forwarded to the host.
@@ -1125,8 +1127,7 @@ The possible error codes returned in `sbiret.error` are shown below.
 === Function: COVE Host Promote to TVM (FID #7)
 [source, C]
 -----
-struct sbiret sbi_covh_promote_to_tvm(unsigned long hgatp,
-                                      unsigned long vcpu_count,
+struct sbiret sbi_covh_promote_to_tvm(unsigned long vcpu_count,
                                       unsigned long entry_sepc,
                                       unsigned long entry_arg,
                                       unsigned long tvm_identity_addr,
@@ -1138,11 +1139,11 @@ require single-step TVM creation (e.g., <<appendix_d>>). Deployment models that
 offer multi-step TVM creation (e.g., <<dep1>>) may, but are not required to,
 support this ABI as an additional mechanism for creating TVMs.
 
-The `hgatp` encodes the physical page number of the VM's page directory and the
-address-translation scheme for guest physical addresses, following the `hgatp`
-CSR encoding.
-The G-stage page tables, rooted at the page directory identified by `hgatp`, and
-data pages must be fully initialized prior to this call.
+Prior to this call, the OS/VMM must set up in non-confidential memory the
+G-stage page tables, rooted at the page directory identified by `hgatp` argument
+passed via NACL shared memory, and data pages. The `hgatp` must encode the
+physical page number of the VM's page directory and the address-translation
+scheme for guest physical addresses, following the `hgatp` CSR encoding.
 
 The `vcpu_count` specifies the number of vCPUs assigned to the TVM. This value
 must be greater than zero and must not exceed `tsm_info.tvm_max_vcpus`.

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -103,7 +103,7 @@ COVH calls.
 
 In the first approach, the OS/VMM promotes an existing non-confidential VM to a
 TVM by invoking the `sbi_covh_promote_to_tvm()` call. As a response to this call,
-the TSM copies the entire VM's state into confidential memory. This is performed
+the TSM moves the entire VM's state into confidential memory. This is performed
 as a single operation after which the newly created TVM is in the `TVM_RUNNABLE`
 state.
 
@@ -300,10 +300,6 @@ interrupt ticking.
                                 to check which interrupts are enabled. This is
                                 useful in waking up a guest's vcpu when it is
                                 sleeping due to a `WFI` instruction.
-| hgatp      |   R   |  W     | Host reflects the address of the page directory
-                                to the TSM during the single-step TVM creation.
-| vs*        |   R   |  W     | Host reflects the vCPU state to the TSM during
-                                the single-step TVM creation.
 | *GPRs*     |       |        |
 | a0         |  RW   |  RW    | Used for both passing argument and returning
                                 the result for ECALLs forwarded to the host.
@@ -1124,58 +1120,91 @@ The possible error codes returned in `sbiret.error` are shown below.
 | SBI_ERR_FAILED        | The operation failed for unknown reasons.
 |===
 
+
 [#sbi_covh_promote_to_tvm]
 === Function: COVE Host Promote to TVM (FID #7)
 [source, C]
 -----
-struct sbiret sbi_covh_promote_to_tvm(unsigned long fdt_addr,
-                                      unsigned long tap_addr,
+struct sbiret sbi_covh_promote_to_tvm(unsigned long hgatp,
+                                      unsigned long vcpu_count,
                                       unsigned long entry_sepc,
-                                      unsigned long tvm_identity_addr);
+                                      unsigned long entry_arg,
+                                      unsigned long tvm_identity_addr,
+                                      unsigned long tap_addr);
 -----
-This intrisic is used by the host to promote a VM to a TVM. It is primarily
-intended for CoVE deployment models that require single-step TVM creation
-(e.g., <<appendix_d>>). Deployment models that offer multi-step TVM creation
-(e.g., <<dep1>>) may, but are not required to, support this ABI as an additional
-mechanism for creating TVMs.
+This function is used by the OS/VMM to promote a non-confidential VM to a TVM in
+a single operation. It is primarily intended for CoVE deployment models that
+require single-step TVM creation (e.g., <<appendix_d>>). Deployment models that
+offer multi-step TVM creation (e.g., <<dep1>>) may, but are not required to,
+support this ABI as an additional mechanism for creating TVMs.
 
-The `fdt_addr` is the 8-bytes aligned guest physical address of the guest
-flattened device tree (FDT).
-The `tap_addr` is the 8-bytes aligned guest physical address of the
-`TVM attestation payload` used for local attestation.
-For VMs that do not require local attestation (only the remote attestation),
-`tap_addr` must be set to `0`.
-The `entry_sepc` is the address at which the vCPU execution will resume.
-`tvm_identity_addr` is an optional, when set, it points to a 8-byte aligned,
-64-bytes buffer containing a host-defined TVM identity,
-see `sbi_covh_finalize_tvm()` for more details.
+The `hgatp` encodes the physical page number of the VM's page directory and the
+address-translation scheme for guest physical addresses, following the `hgatp`
+CSR encoding.
+The G-stage page tables, rooted at the page directory identified by `hgatp`, and
+data pages must be fully initialized prior to this call.
 
-The VM should be promoted as early in the boot process as possible to minimize
-changes in memory contents so that the resulting integrity measurement hashes
-are deterministic. The VM must not use registers associated with RISC-V
-extensions, e.g., vector, floating point, before promotion, because these
-registers will be zeroized during the promotion.
+The `vcpu_count` specifies the number of vCPUs assigned to the TVM. This value
+must be greater than zero and must not exceed `tsm_info.tvm_max_vcpus`.
 
-The TVM vCPUs are recreated in confidential memory. The TSM reads the number of
-vCPUs from the FDT and sets all TVM vCPUs but the TVM's boot vCPU to reset state.
-The TVM's boot vCPU state is reflected in NACL shared memory and its program
-counter value in the `entry_sepc` call's argument. The TSM recreates in
-confidential memory the reflected VM's data and the VM's page tables, following
-the page table configuration defined in HGATP.
+The `entry_sepc` is the guest physical address at which the boot vCPU will begin
+execution.
 
-Once the TVM's image is completed, the TSM calculates the TVM measurement.
-If `tap_addr` is defined, the TSM uses this TVM measurement to authenticate and
-authorize the TVM as part of the local attestation procedure.
+The `entry_arg` is the guest physical address of the guest flattened device tree
+(FDT). It is passed to the boot vCPU in the `a1` GPR.
 
-If successful, the TSM sets the TVM state to `TVM_RUNNABLE` and returns a unique
-TVM identifier (`tvm_guest_id`) to the OS/VMM.
-The OS/VMM should free the contents of non-confidential memory that contains the
-VM's data and the page tables. After this call, the OS/VMM must interact with
-this TVM via the TSM using the COVH ABI, i.e., resuming the TVM using the
-`sbi_covh_run_tvm_vcpu()` call.
+`tvm_identity_addr` is optional. When non-zero, it must point to a 64-byte,
+8-byte aligned buffer containing a host-defined TVM identity.
+See `sbi_covh_finalize_tvm()` for the semantics of the TVM identity.
 
-If the call fails, the TSM returns the SBI error code in `sbiret.error` to the
-OS/VMM. The possible error codes are shown below.
+`tap_addr` is the 8-byte aligned guest physical address of the TVM Attestation
+Payload (TAP), used for local attestation. For TVMs that require only remote
+attestation, `tap_addr` must be set to `0`.
+
+To promote the VM, the TSM performs the following steps.
+
+First, the TSM recreates the VM's page tables and data pages in confidential
+memory, following the page table configuration defined by `hgatp`. For each
+leaf page table entry (PTE), the TSM decodes the page type from bits 8–9
+(the RSW field) as follows:
++
+[cols="1,3"]
+|===
+| RSW value | Page type
+
+| `0b00` | Measured page — content is extended to PCR 0.
+| `0b01` | Measured page — content is extended to PCR 1.
+| `0b10` | Measured page — content is extended to PCR 2.
+| `0b11` | Zero page — the page must be zero-filled in confidential memory
+            or left unmapped and demand-faulted on first TVM access.
+            Zero pages are not measured.
+|===
+
+Next, the TSM creates `vcpu_count` vCPUs. All vCPUs are initialized to
+architectural reset state. The boot vCPU's `sepc` is set to `entry_sepc`, `a0`
+to the boot hart's identifier, and `a1` to `entry_arg`.
+
+Next, the TSM calculates the TVM integrity measurements over the TVM's
+confidential memory image, including all measured pages and vCPU initial state.
+Both `entry_sepc` and `entry_arg` are included in the measurement. The
+measurement of data pages should already take place in step 1 to avoid
+unnecessary memory reads during promotion.
+
+If `tap_addr` is non-zero, the TSM uses the TVM measurements to authenticate and
+authorize TVM execution as part of the local attestation procedure.
+
+Finally, the TSM sets the TVM state to `TVM_RUNNABLE` and returns a unique TVM
+identifier (`tvm_guest_id`) in `sbiret.value`.
+
+Note that a TVM created via this call does not require a subsequent call to
+`sbi_covh_finalize_tvm()`.
+Upon successful return, the OS/VMM should release the non-confidential memory
+that contained the VM's data and page tables. Subsequently, the OS/VMM must
+interact with the TVM exclusively via the COVH ABI, resuming vCPU execution via
+`sbi_covh_run_tvm_vcpu()`. The boot vCPU must be run before any other vCPU.
+
+If the call fails, the TSM returns an error code in `sbiret.error`. The possible
+error codes are shown below.
 
 [#table_sbi_covh_promote_to_tvm_errors]
 .COVE Host Promote to TVM Errors
@@ -1183,9 +1212,9 @@ OS/VMM. The possible error codes are shown below.
 |===
 | Error code              | Description
 | SBI_SUCCESS             | The operation completed successfully.
-| SBI_ERR_INVALID_ADDRESS | `fdt_addr` was invalid.
+| SBI_ERR_INVALID_ADDRESS | Page table configuration as defined by `hgatp` is invalid.
 | SBI_ERR_AUTH            | Local attestation failed.
-| SBI_ERR_OUT_OF_MEMORY   | Not enough confidential memory to store TVM.
+| SBI_ERR_OUT_OF_MEMORY   | Not enough confidential memory to create a TVM.
 | SBI_ERR_FAILED          | The operation failed for unknown reasons.
 |===
 
@@ -2451,9 +2480,6 @@ TSM will write the secret.
 `buf_size` is the length of the buffer. The buffer cannot be larger than the
 4 KiB page size.
 
-This ABI will become part of the `Sealing Interface` planned for the CoVE in
-version 2.0.
-
 If the call fails, the TSM returns SBI error code in `sbiret.error` to the VM.
 The possible error codes are shown below.
 
@@ -2551,7 +2577,7 @@ the TVM virtual harts cannot be entered unless the TVM measurement is committed
 via this operation.
 
 | <<sbi_covh_promote_to_tvm, sbi_covh_promote_to_tvm>>  | Creates a TVM in
-a single-step taking the state of an existing VM and recreating it in
+a single-step taking the state of a VM and recreating it in
 confidential memory. It is an alternative approach to creating a TVM in
 a multi-step process initiated with `sbi_covh_create_tvm()`.
 

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -1133,7 +1133,7 @@ struct sbiret sbi_covh_promote_to_tvm(unsigned long vcpu_count,
                                       unsigned long tvm_identity_addr,
                                       unsigned long tap_addr);
 -----
-This function is used by the OS/VMM to promote a non-confidential VM to a TVM in
+This function is used by the OS/VMM to create a TVM in
 a single operation. It is primarily intended for CoVE deployment models that
 require single-step TVM creation (e.g., <<appendix_d>>). Deployment models that
 offer multi-step TVM creation (e.g., <<dep1>>) may, but are not required to,
@@ -1162,7 +1162,7 @@ See `sbi_covh_finalize_tvm()` for the semantics of the TVM identity.
 Payload (TAP), used for local attestation. For TVMs that require only remote
 attestation, `tap_addr` must be set to `0`.
 
-To promote the VM, the TSM performs the following operations.
+To promote to a TVM, the TSM performs the following operations.
 
 The TSM recreates the VM's page tables and data pages in confidential
 memory, following the page table configuration defined by `hgatp`. For each

--- a/src/swlifecycle.adoc
+++ b/src/swlifecycle.adoc
@@ -85,21 +85,25 @@ finalized.
 The OS/VMM can create a new TVM in a single operation by requesting the TSM to
 construct a TVM from the existing non-confidential VM.
 First, the OS/VMM creates a regular VM by allocating memory for the VM's data
-and vCPUs and creating the G-Stage page table configuration. This is a standard
-process for creating non-confidential VMs implemented by existing OS/VMMs. In
-response to a request from a VM, `sbi_promote_to_tvm()`, the OS/VMM requests the
-TSM to promote the VM by executing the `sbi_covh_promote_to_tvm()` call. The TSM
-creates a new TVM from the reflected VM state (VM data, page table configuration
-, vCPU state). After promotion, the OS/VMM releases the previously allocated VM
-resources and begins interacting with the TVM through the TSM as described in
-the next sections.
+and vCPUs and creating the G-stage page table configuration. This is a standard
+process for creating non-confidential VMs implemented by existing OS/VMMs. The
+OS/VMM requests then the TSM to promote the VM by executing the
+`sbi_covh_promote_to_tvm()` call. The TSM recreates a new TVM from the reflected
+VM state (VM data, page table configuration, vCPU state). After promotion, the
+OS/VMM should release the previously allocated VM resources and must begin
+interacting with the TVM through the TSM as described in the next sections.
 
-[NOTE]
-====
-The promotion should be done early during the TVM's bootstrap so that the
-integrity measurements calculated by TSM over the TVM data in confidential
-memory are deterministic and therefore meaningful for attestation.
-====
+The mechanism by which the TSM recreates the VM state in confidential memory is
+implementation-specific. In CoVE implementations that support dynamic conversion
+between confidential and non-confidential memory, the TSM should perform page
+conversion while traversing G-stage page-table mappings. Conversely, CoVE
+implementations that support only static memory partitioning, or that seek to
+reduce the attack surface by preventing the VMM/OS from selecting the physical
+locations of TVM's pages, must instead assign the TSM authority to allocate
+physical pages within confidential memory. Such designs incur greater TSM
+implementation complexity, as the TSM must provide its own page-allocation
+mechanism, and may incur additional performance overhead, as the TSM must copy
+VM data from non-confidential pages into confidential pages during promotion.
 
 === TVM execution
 

--- a/src/swlifecycle.adoc
+++ b/src/swlifecycle.adoc
@@ -96,14 +96,14 @@ interacting with the TVM through the TSM as described in the next sections.
 The mechanism by which the TSM recreates the VM state in confidential memory is
 implementation-specific. In CoVE implementations that support dynamic conversion
 between confidential and non-confidential memory, the TSM should perform page
-conversion while traversing G-stage page-table mappings. Conversely, CoVE
+conversion. Conversely, CoVE
 implementations that support only static memory partitioning, or that seek to
 reduce the attack surface by preventing the VMM/OS from selecting the physical
 locations of TVM's pages, must instead assign the TSM authority to allocate
 physical pages within confidential memory. Such designs incur greater TSM
 implementation complexity, as the TSM must provide its own page-allocation
 mechanism, and may incur additional performance overhead, as the TSM must copy
-VM data from non-confidential pages into confidential pages during promotion.
+VM data from non-confidential pages into confidential pages.
 
 === TVM execution
 


### PR DESCRIPTION
This PR simplifies the single-step TVM creation triggered by the sbi_covh_promote_to_tvm() call by reducing the dependency on FDT and making information needed to create a TVM explicit. It also postpones the creation of a TVM from a running VM to CoVE v2, because we then expect to define the full TVM architectural state as part of the TVM migration spec.