### PR TITLE
Use ghcr.io/riscv/riscv-docs-base-container-image:latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ DOCS := \
 
 ifneq ($(SKIP_DOCKER),true)
 	DOCKER_CMD := docker run --rm -v ${PWD}:/build -w /build \
-	riscvintl/riscv-docs-base-container-image:latest \
+	ghcr.io/riscv/riscv-docs-base-container-image:latest \
 	/bin/sh -c
 	DOCKER_QUOTE := "
 endif


### PR DESCRIPTION
This updates the docs container image reference in the root Makefile.

The old `riscvintl` image has been replaced with the `ghcr.io/riscv` image.
