### PR TITLE
Fix CoVE typos

### DIFF
--- a/src/appendix_d.adoc
+++ b/src/appendix_d.adoc
@@ -113,7 +113,7 @@ improperly configured or unauthorized hardware, there should be a mechanism
 supported by hardware (and firmware) for verification.
 Assuming presence of the hardware root-of-trust for measurement and hardware
 root-of-trust for storage, the VM can be created with an encrypted disk and the
-key that is used to decrypt the disk can be sealed to the measurments of the
+key that is used to decrypt the disk can be sealed to the measurements of the
 platform.
 The creator of the VM using the specifications for the platform decides what
 values are required in order for the key to be released.

--- a/src/bibliography.adoc
+++ b/src/bibliography.adoc
@@ -82,3 +82,5 @@ https://datatracker.ietf.org/doc/rfc5752/
 * [[[TEEFAIL,27]]] TEE.fail: Breaking Trusted Execution Environments via DDR5 Memory Bus Interposition
 https://TEE.fail
 
+* [[[ROWHAMMER,28]]] Row Hammer
+https://en.wikipedia.org/wiki/Row_hammer

--- a/src/bibliography.adoc
+++ b/src/bibliography.adoc
@@ -79,4 +79,6 @@ https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf
 * [[[RFC5752,26]]] IETF RFC 5752 Multiple Signatures in Cryptographic Message Syntax (CMS)
 https://datatracker.ietf.org/doc/rfc5752/
 
-bibliography::[]
+* [[[TEEFAIL,27]]] TEE.fail: Breaking Trusted Execution Environments via DDR5 Memory Bus Interposition
+https://TEE.fail
+

--- a/src/glossary.adoc
+++ b/src/glossary.adoc
@@ -64,7 +64,7 @@ resources.
 
 | MMU | Memory management unit (MMU).
 
-| MTT | Memory Tracking Table (MTT).
+| MPT | Memory Protection Table (MPT).
 
 | Relying party | An entity that depends on the validity of information about
 another entity, typically for purposes of authorization <<RATS>>.

--- a/src/refarch.adoc
+++ b/src/refarch.adoc
@@ -387,7 +387,7 @@ any v/f register state must be restored by the caller.
 * TSM-driver passes TSM/TVM-specified register contents to the OS/VMM to
 return status from TEERET (TSM sets a0, a1 registers always - other
 registers may be selected by the TVM)
-* Enable hosting supervisor domain on hart (via Superisor Domains <<RVISD>>
+* Enable hosting supervisor domain on hart (via Supervisor Domains <<RVISD>>
 M-mode CSR `mmpt` to disable non-TCB accesses to confidential memory.)
 * MRET to resume execution in OS/VMM at mepc set to THCS.hssa.pc
 (THCS.hssa.pc adjusted to refer to opcode after the ECALL that triggered

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -36,7 +36,7 @@ as allocated in <<table_cove_fid_namespaces>>.
 Other future specifications (e.g., CoVE-IO) may need to extend one of the three
 CoVE SBI extensions with domain specific functions. In order to support that
 requirement each one of the CoVE extensions SBI function IDs (`FID`) in the
-availabe 64K range is split into separate namespaces.
+available 64K range is split into separate namespaces.
 
 The main CoVE specification uses SBI's function identifiers (FIDs) from 0 to
 1023 (inclusive), and other specifications can extend the CoVE SBI by reserving
@@ -1126,7 +1126,7 @@ struct sbiret sbi_covh_promote_to_tvm(unsigned long fdt_addr,
                                       unsigned long entry_sepc,
                                       unsigned long tvm_identity_addr);
 -----
-This intrisic is used by the host to promote a VM to a TVM. It is primarily
+This intrinsic is used by the host to promote a VM to a TVM. It is primarily
 intended for CoVE deployment models that require single-step TVM creation
 (e.g., <<appendix_d>>). Deployment models that offer multi-step TVM creation
 (e.g., <<dep1>>) may, but are not required to, support this ABI as an additional
@@ -2270,7 +2270,7 @@ struct AttestationCapabilities {
     enum HashAlgorithm hash_algorithm;
 
     /*
-     * The supported attesation certificate formats.
+     * The supported attestation certificate formats.
      * This is a bitmap of ATTESTATION_CERTIFICATE_* flags.
      */
     uint32_t certificate_formats;
@@ -2384,9 +2384,9 @@ If the `sbi_covg_get_attcaps` enumerates attestation services provided by
 the TSM, then this intrinsic is used by a TVM to get an attestation evidence to
 report to a remote relying party.
 
-This intrisic returns an attestation certificate at the address passed as its
+This intrinsic returns an attestation certificate at the address passed as its
 fifth argument (`cert_addr_out`). The certificate is signed by the TSM
-attestation key, and includes the TVM attestation evidence. The TSM attestion
+attestation key, and includes the TVM attestation evidence. The TSM attestation
 key is also included in the reported TSM token.
 
 The caller passes the TVM public key address as the first argument
@@ -2395,7 +2395,7 @@ represents the TSM-certified TVM identity.
 
 The third argument (`challenge_data_addr`) points to the attestation challenge
 blob, typically a relying party generated nonce used for demonstrating the
-attestation evidence fresheness.
+attestation evidence freshness.
 
 The fourth argument (`cert_format`) is the caller's selected attestation
 certificate format. This must be one of the supported
@@ -2468,12 +2468,12 @@ struct sbiret sbi_covg_read_measurememt(unsigned long msmt_buf_addr_out,
                                              unsigned long msmt_buf_size,
                                              unsigned long msmt_index);
 -------
-This intrisic returns a TVM measurement register value for the `msmt_index`
+This intrinsic returns a TVM measurement register value for the `msmt_index`
 measurement register. TVMs can read both initial and runtime measurement
 register values back.
 
 `sbi_covg_read_measurement` returns the register value at `msmt_buf_addr_out`
-and `msmt_buf_size` must be large enough to accomodate for the hash function
+and `msmt_buf_size` must be large enough to accommodate for the hash function
 algorithm output length, as reported by `sbi_covg_get_attcaps`.
 
 `msm_index` must be one of the `sbi_covg_get_attcaps` reported measurement
@@ -2783,14 +2783,14 @@ reported one.
 intrinsic is used by a TVM to get an attestation evidence to
 report to a remote relying party. It returns an attestation certificate signed
 by the TSM attestation key, and includes the TVM attestation evidence. The TSM
-attestion key is also included in the reported TSM token.
+attestation key is also included in the reported TSM token.
 
 | <<sbi_covg_retrieve_secret, sbi_covg_retrieve_secret>>      | TVM reads a secret
 available after successful local attestation. TSM writes the secret to the
 buffer specified by the TVM.
 
 | <<sbi_covg_read_measurement, sbi_covg_read_measurement>>      | This
-intrisic returns a the TVM measurement register value for the `msmt_index`
+intrinsic returns a the TVM measurement register value for the `msmt_index`
 measurement register. TVMs can read both initial and runtime measurement
 register values back.
 

--- a/src/swlifecycle.adoc
+++ b/src/swlifecycle.adoc
@@ -195,7 +195,7 @@ access-control is enforced at two levels:
 * Isolation of memory assigned to the confidential supervisor domain (TSM and
 TVMs).
 This tracking is configured by the firmware TCB (TSM-driver) and enforced using
-a hardware memory isolation mechanism, e.g., Memory Tracking Table (MTT), PMP.
+a hardware memory isolation mechanism, e.g., Memory Protection Table (MPT), PMP.
 These mechanisms track access permissions for confidential supervisor domains
 and hosting supervisor domains for all software-accessible physical memory
 addresses.
@@ -205,10 +205,10 @@ structures to maintain compatibility with OS/VMM memory management, and is also
 enforced by the CPU's memory management unit (MMU). The correct operation of
 this access-control level is dependent on trusted enforcement of item 1 above.
 
-In CoVE implementations that support MTT, the TSM-driver configures the MTT
+In CoVE implementations that support MPT, the TSM-driver configures the MPT
 after enforcing the security requirements to track the assignment of memory
 pages to a supervisor domain/TSM. The TSM manages subsequent assignment of
-memory to TVMs. In implementations that do not implement MTT, memory must be
+memory to TVMs. In implementations that do not implement MPT, memory must be
 statically partitioned into confidential and non-confidential and the TSM is
 required to track assignment of pages in confidential memory to TVMs.
 
@@ -243,15 +243,15 @@ the GPA and enforced for memory access for the TVM by the hardware.
 
 ====  Information tracked per physical page
 
-For implementations that utilize MTT, the Extended Memory Tracking Table (EMTT)
+For implementations that utilize MPT, the Extended Memory Protection Table (EMPT)
 information managed by the TSM
 is used to track additional fields of metadata associated with physical
 addresses.
-The page size is implicit in the MTT and EMTT lookup - 4 KiB, 2 MiB, 1 GiB, 512 GiB.
+The page size is implicit in the MPT and EMPT lookup - 4 KiB, 2 MiB, 1 GiB, 512 GiB.
 Actual page sizes supported are implementation-specified.
 
 |===
-h| Memory Type h| Confidential or Non-confidential (enforced via MTT)
+h| Memory Type h| Confidential or Non-confidential (enforced via MPT)
 | Page-Type
 a| Reserved - page that may not be assigned to any TEE entity.
 
@@ -259,7 +259,7 @@ If the Memory Type is Confidential, the following page types may be used:
 
 * Unassigned - page not assigned to any TEE (TSM or TVM)
 * TVM - page assigned to a TVM (mapped via G-stage page table)
-* TSM - page used by the TSM (for MTT and other control structures)
+* TSM - page used by the TSM (for MPT and other control structures)
 | Page Owner  | If the Memory Type is Confidential and Page-Type is TVM,
 this value holds the identifier (e.g., PPN) for the TVM control page (4 KiB TEE-
 TSM-TVM page); else it is 0.
@@ -271,7 +271,7 @@ Page-Type is TVM:
 
 Following types apply if Memory Type is Confidential and Page-Type is TSM:
 
-* MTT - pages used for MTT structures
+* MPT - pages used for MPT structures
 * TVMC - pages used for TVM control structure(s) for global control
 * VHCS - pages used for TVM VHCS (virtual hart control structures)
 | Page TLB version | TLB version in which the page mapping was invalidated to
@@ -290,9 +290,9 @@ expected to cause a lookup of the address translation structure using the
 physical address (PA) and the resolved page size for TEE access evaluation -
 which results in the TEE access information that is cached.
 
-In CoVE implementations with MTT, the MTT lookups are performed using the
+In CoVE implementations with MPT, the MPT lookups are performed using the
 physical address, and must be enforced for all modes of operation i.e., with
-paging disabled, one-level paging and guest-stage paging. Any MTT-cached
+paging disabled, one-level paging and guest-stage paging. Any MPT-cached
 information may be flushed as part of HFENCE.GVMA. The TSM and VMM may both
 issue this operation. TSM issues this fence when memory access is transferred
 between TEE and non-TEE domains via `sbi_covh_convert_pages()`.
@@ -300,7 +300,7 @@ between TEE and non-TEE domains via `sbi_covh_convert_pages()`.
 ==== Page conversion
 
 This section refers to CoVE implementations supporting page conversion, i.e.,
-implementing MTT.
+implementing MPT.
 
 Post measured boot, the system memory map must be available to the TSM on load
 (accessed as part of initialization of the TSM). This memory map structure may
@@ -308,7 +308,7 @@ be placed in the memory that is accessible only to the hardware and software
 TCB. VMM-chosen memory regions must be a strict subset of this set of memory
 regions. Memory regions used for the TSM are marked as reserved by the
 TSM-driver in this memory map - the TSM uses its memory space to host an
-Extended MTT (EMTT).
+Extended MPT (EMPT).
 
 The operations used by the host for page conversion are:
 
@@ -323,16 +323,16 @@ available physical harts have executed this operation before it considers the
 TLB version updated. The last local fence completes the conversion of a memory
 region from non-confidential to confidential for a set of TVM pages.
 * sbi_covh_reclaim_pages: VMM may unassign memory for TVMs by destroying them.
-All confidential-unassigned memory may be reclaimed back as nonconfidential
+All confidential-unassigned memory may be reclaimed back as non-confidential
 using this interface.
 
-*Conversion Operation*: TSM uses the EMTT which maps each assignable
+*Conversion Operation*: TSM uses the EMPT which maps each assignable
 (non-reserved) PA to page_owner, type, sub-type and other fields such as
 page_tlb_version. Page conversion involves the following steps by the TSM:
 
 * Verify page(s) donated by the VMM is/are Non-Confidential page(s)
 * Initiates a new TLB version tracking cycle via `sbi_covh_convert_pages()` -
-invalidates MTT entries (synchronized) for the requested page(s) and size as
+invalidates MPT entries (synchronized) for the requested page(s) and size as
 pages being converted to confidential (i.e., "in transition")
 * TSM enforces a TLB versioning scheme (described below) and using that
 enforces that the VMM performs the invalidation of the hart TLBs (via IPIs) to
@@ -399,7 +399,7 @@ The TSM tracks global TLB version for memory conversions and via the per-TVM
 and per-vcpu control structures tracks TVM-scoped TLB versions. The TSM also
 maintains reference counts for the number of harts that were activated during a
 TLB version. A similar TLB version is managed associated with the physical
-address in the EMTT.
+address in the EMPT.
 
 If the VMM initiates memory conversion to confidential, or any change to an
 assigned confidential and present guest physical address (GPA) mapping for a
@@ -408,7 +408,7 @@ sequence (enforced by TSM) to affect that change:
 
 * Invalidate the mapping it wants to modify (page or range of pages). This step
 prevents new cached mappings from being populated in the TLB.
-* In the PA metadata maintained by the TSM (EMTT), captures into the per-page
+* In the PA metadata maintained by the TSM (EMPT), captures into the per-page
 metadata, the TLB version at which the conversion was initiated or the mapping
 was invalidated.
 * Initiate global or per-TVM fence/increment the TLB version for the platform
@@ -429,7 +429,7 @@ during the vcpu run.
 mappings exist at this point -----
 * Invoke the specific mapping change operation, such as remove, relocate,
 promote, migrate etc.
-* Checks that the affected mapping(s) are invalidated in the MTT and/or G-stage
+* Checks that the affected mapping(s) are invalidated in the MPT and/or G-stage
 mapping and validate the mapping.
 * Subsequent page walks may create cached mappings from this point onwards.
 
@@ -447,7 +447,7 @@ page(s) to be used for the hgatp structure entries
 
 * Verify that the TVM has been created successfully.
 * Verify that the PPN(s) for the new page(s) to be used for TVM hgatp is/are
-Unassigned-Confidential per the EMTT.
+Unassigned-Confidential per the EMPT.
 * For the GPA to be mapped, perform a TVM-hgatp walk to locate the non-leaf
 entry that should refer to the new page being added (to hold the next level of
 the mapping for the GPA). If the mapping already exists, the operation is
@@ -455,7 +455,7 @@ aborted.
 * Initialize the new hgatp page to zero (no hgatp page table entries are valid).
 * Update the parent hgatp entry to refer to the new hgatp page (mark non-lead
 as valid).
-* Update the hgatp page EMTT entry with the TVM owner-id and page-type.
+* Update the hgatp page EMPT entry with the TVM owner-id and page-type.
 
 ==== Measured page assignment into a TVM memory map
 
@@ -486,7 +486,7 @@ and page size to be used for the guest mapping to be added.
 * Verify that the TVM has been created successfully.
 * If the source page is provided, this operation can only be performed if the
 TVM measurement has not been finalized.
-* Verify that the PFN for the new page to be used for TVM is free in the MTT.
+* Verify that the PFN for the new page to be used for TVM is free in the MPT.
 * For the GPA to be mapped, perform a TVM-hgatp walk to locate the leaf entry
 that should refer to the new page being added. If the mapping does not exist OR
 exists but is not in the unmapped state, the operation is aborted.
@@ -496,7 +496,7 @@ initialization of memory will be performed by the TSM in the context of the
 confidential supervisor domain and via the TSMs paging structure of the PA
 assigned to the TVM - hence the memory will be treated as confidential.
 * The measurement of the TVM is extended with the GPA used to map to the page.
-* Update the TVM page MTT entry with the TVM owner PPN and page type as TEE-TVM.
+* Update the TVM page MPT entry with the TVM owner PPN and page type as TEE-TVM.
 * Update the leaf hgatp page table entry to refer to the new page (mark leaf as
 valid) to allow TLB mappings to be created when the TVM vcpu is executing
 subsequently.
@@ -542,7 +542,7 @@ enforce that it injects only interrupts allow-listed by the TVM.
 Hardware-accelerated interrupt-controller virtualization is possible for TVMs on
 platform supporting the Advanced Interrupt Architecture [AIA] and an
 implementation-defined method of isolating IMSIC guest interrupt files between
-the non-TEE and TEE worlds (either using an MTT as described above, or via other
+the non-TEE and TEE worlds (either using an MPT as described above, or via other
 means). This enables delivery of MSIs from TVM-assigned devices and
 inter-processor interrupts without OS/VMM interference for TVM virtual harts.
 
@@ -737,9 +737,9 @@ non-confidential VM. TSM memory reclaim operation:
 
 * Verifies that the PAs referenced are either Non-confidential (No-operation) or
 Confidential-Unassigned state.
-* TSM takes exclusive lock over the MTT tracker entry for the PA.
+* TSM takes exclusive lock over the MPT tracker entry for the PA.
 * TSM scrubs page contents.
-* TSM updates MTT tracker entry (synchronized) for the page as Non-confidential
+* TSM updates MPT tracker entry (synchronized) for the page as Non-confidential
 and returns the PA as an Non-Conf page to the VMM.
 * VMM translations to the PA (via 1st or G stage mappings) may be created now.
 

--- a/src/threatmodel.adoc
+++ b/src/threatmodel.adoc
@@ -139,7 +139,7 @@ adversaries that may modify TSM/TVM memory via CPU side accesses.
 ==== CoVE-T003 - Malicious tamper of TVM memory state via row-hammer
 
 Tamper of TVM/TSM memory from in-scope adversaries via software-induced
-row-hammer attacks on memory.
+row-hammer <<ROWHAMMER>> attacks on memory.
 
 .CoVE-T003
 [options="header"]
@@ -156,7 +156,7 @@ row-hammer attacks on memory.
 
 6+^| **Description**
 6+a| A privileged host software component directly accesses non-confidential
-     memory adjoining confidential memory to exercise RowHammer <<ROWHAMMER>> attacks. +
+     memory adjoining confidential memory to exercise row-hammer attacks. +
      A TVM uses row-hammer to target another TVMs or ordinary VMs memory via
      row-hammer approaches.
 

--- a/src/threatmodel.adoc
+++ b/src/threatmodel.adoc
@@ -426,7 +426,7 @@ to a TVM must enforce similar properties as the TEE hosted on the platform.
      programming the IO-MPT to associate the device with the IOMMU and SDID. +
      The TSM must enforce that the device page tables prevent untrusted TVMs
      from accessing TVM confidential memory. +
-     Please refer to <<RVICOVEIO>> for a detailed threat model for devices
+     Please refer to CoVE-IO <<RVICOVEIO>> for a detailed threat model for devices
      assigned to a TVMs.
 |===
 

--- a/src/threatmodel.adoc
+++ b/src/threatmodel.adoc
@@ -156,7 +156,7 @@ row-hammer attacks on memory.
 
 6+^| **Description**
 6+a| A privileged host software component directly accesses non-confidential
-     memory adjoining confidential memory to exercise [RowHammer](https://en.wikipedia.org/wiki/Row_hammer) attacks. +
+     memory adjoining confidential memory to exercise RowHammer <<ROWHAMMER>> attacks. +
      A TVM uses row-hammer to target another TVMs or ordinary VMs memory via
      row-hammer approaches.
 
@@ -269,7 +269,7 @@ registers, CSRs, mode switches via adversaries using physical attacks.
      hardware mechanisms.
 |===
 
-==== CoVE-T007 - Malicioud code/data access via G-stage page table remap attacks
+==== CoVE-T007 - Malicious code/data access via G-stage page table remap attacks
 Invalid code execution or data injection/replacement via G-stage
 paging remap attacks via system software adversary.
 
@@ -384,7 +384,7 @@ control, e.g., via manipulation of IOMMU programming.
 | Attacker accesses TVM data via DMA via IOMMU programming
 
 6+^| **Description**
-6+a| A privileged host software componenent programs the IOMMU to redirect DMA
+6+a| A privileged host software component programs the IOMMU to redirect DMA
      access to confidential memory, and thus write or read confidential memory.
 
 6+^| **Mitigations**
@@ -394,7 +394,7 @@ control, e.g., via manipulation of IOMMU programming.
      access to memory-mapped interfaces to platform devices. +
      The RDSM may assign an IOMMU to a supervisor domain, allowing the TSM to
      manage the IOMMU for devices associated with the domain. +
-     Please refer to CoVE-IO [Ref] for a detailed threat model for devices
+     Please refer to CoVE-IO <<RVICOVEIO>> for a detailed threat model for devices
      assigned to a TVMs.
 |===
 
@@ -547,7 +547,7 @@ dictionary attack on TCB components to extract confidential data.
      cpu state by using RISC-V privileged ISA privilege levels (M, S, HS, U) and
      must enforce cipher text read prevention using Sv (MMU), PMP, Smmpt to
      prevent non-TCB components from accessing encrypted TEE memory +
-     See reference TEE.fail [[Ref](https://tee.fail/)]
+     See reference TEE.fail <<TEEFAIL>>.
 |===
 
 ==== CoVE-T015 - Tamper of TVM state during TVM Migration
@@ -588,7 +588,7 @@ the platform or from one platform to another.
 |===
 
 ==== CoVE-T016 - Host generates malicious TVM attestation evidence
-Forging attestation evidence or attcks on TCB that lead to invalid attestation
+Forging attestation evidence or attacks on TCB that lead to invalid attestation
 evidence for a TVM. Downgrading TEE TCB elements (RDSM, TSM) to older
 versions or loading invalid TEE TCB elements on the platform to enable
 secondary confidentiality, integrity attacks.
@@ -613,7 +613,7 @@ secondary confidentiality, integrity attacks.
 
 6+^| **Mitigations**
 6+a| The platform TCB (RoT, RDSM, TSM) must enforce the measured boot chain to
-     enforce measurment of all TCB elements, and implement a RTM (root of trust
+     enforce measurement of all TCB elements, and implement a RTM (root of trust
      for measurement) and RTR (root of trust for reporting) functions to record
      and report measurements of TCB elements as cryptographically-signed
      evidence of the static and dynamic state of the TCB. +
@@ -632,7 +632,7 @@ secondary confidentiality, integrity attacks.
      updatable at runtime without requiring platform resets. TVMs may opt-in
      if TCB updates are permitted. +
      The TEE TCB should not be affected by other TCB reporting chains. TEE TCB
-     is seperately reportable and recoverable.
+     is separately reportable and recoverable.
 |===
 
 ==== CoVE-T017 - Malicious creation of stale address translation cache entries
@@ -834,7 +834,7 @@ or on other TVMs or ordinary VM workloads.
 
 |===
 
-==== CoVE-T023 - Malicious host or TVM exflitrates data via shared memory
+==== CoVE-T023 - Malicious host or TVM exfiltrates data via shared memory
 
 .CoVE-T023
 [options="header"]
@@ -854,13 +854,13 @@ or on other TVMs or ordinary VM workloads.
      or TEE domain to leak data via shared memory regions.
 
 6+^| **Mitigations**
-6+a| The RDSM and TSM must enforce access-control permisions for shared memory
+6+a| The RDSM and TSM must enforce access-control permissions for shared memory
      between TVMs and non-TCB components using mechanisms such as Sv (MMU),
      PMP, Smmpt and optionally cryptography via a seperate key for shared
      memory with hosting software. +
      The TSM must prevent non-TCB code from setting up shared memory regions
      accessible in the G-stage structures without TVM consent. +
-     The TSM must enforce invalidatin of address-translation caches when a
+     The TSM must enforce invalidation of address-translation caches when a
      memory region is downgraded from confidential to shared or from shared to
      confidential.
 


### PR DESCRIPTION
- Couple of typos in various chapters
- fixed (E)MMT to (E)MPT
- added two entries to bibliography (row-hammer, TEE.fail)