### PR TITLE
Fixes around the spec that adress some of the open issues

### DIFF
--- a/src/attestation.adoc
+++ b/src/attestation.adoc
@@ -95,7 +95,7 @@ measurements and a runtime one.
 TVM initial measurements are generated from the CoVE workload TCB elements
 involved in the TVM construction. Any TCB element that directly or indirectly
 supports a TVM must be measured into the TVM initial measurement registers. Once
-a TVM is finalized, i.e., after the `sbi_tee_host_finalize_tvm()` TH-ABI is
+a TVM is finalized, i.e., after the `sbi_covh_finalize_tvm()` TH-ABI is
 called, the TVM initial measurements must no longer be extended.
 
 Each TVM's initial measurements are stored in dedicated measurement registers
@@ -652,7 +652,7 @@ tvm-challenge = (
 
 ====== TVM Identity Claim
 
-The TVM identity claim value is a `sbi_tee_host_finalize_tvm()` provided
+The TVM identity claim value is a `sbi_covh_finalize_tvm()` provided
 argument. It is an optional claim and is not included in the TVM token when
 the TVM identity argument is set to 0.
 

--- a/src/refarch.adoc
+++ b/src/refarch.adoc
@@ -134,9 +134,9 @@ property of the MPT and are discussed next:
 
 ==== Address Translation/Page Walk
 Figure 2 describes a reference model for memory protection table lookup where
-the physical address derived from the two-stage address translation and
+the host physical address derived from the two-stage address translation and
 protection mechanism is looked up via the MPT configured for the active
-supervisor domain to get the access permissions for the physical address. This
+supervisor domain to get the access permissions for the host physical address. This
 lookup should be performed for each implicit and explicit memory access and per
 the paging sizes/modes supported by the hart.
 

--- a/src/refarch.adoc
+++ b/src/refarch.adoc
@@ -50,7 +50,7 @@ detail.
 === CoVE Memory Isolation
 Memory isolation for TVMs is orchestrated by the TSM-driver and the TSM in two
 phases: the conversion of memory to confidential memory and the assignment of
-confidential memory (alongwith the enforcement of properties on use) to TVMs.
+confidential memory (along with the enforcement of properties on use) to TVMs.
 To enforce isolation across Host and Confidential supervisor domains, CoVE
 requires isolation of physical memory (that supports paging when enabled).
 
@@ -271,10 +271,10 @@ assigned to the TVM by the VMM.
 
 === TSM operation and properties
 
-The TSM implements COVH APIs that are invoked by the OS/VMM or by
-the TVMs, e.g., by the VMM to grant a TVM a confidential memory page and
-setup second-stage mapping, activate a TVM virtual hart on a physical hart
-etc. The TSM security routines are invoked by the OS/VMM via an ECALL with
+The TSM implements COVH APIs that are invoked by the OS/VMM, e.g., by the VMM to
+grant a TVM a confidential memory page and setup G-stage mapping, activate a
+TVM virtual hart on a physical hart etc.
+The TSM security routines are invoked by the OS/VMM via an ECALL with
 the service call specified via registers. These service calls trap to the
 TSM-driver. The TSM-driver switches hart state to the TSM context by
 loading the hart's TSM execution state from the THCS.tssa and then returns
@@ -288,7 +288,7 @@ medeleg).
 The TSM saves the TVM state and invokes the TSM-driver via an ECALL (TEERET
 with reason) to initiate the return of execution control to the OS/VMM if
 required. The TSM-driver restores the context for the OS/VMM via the
-per-hart control sub-structure THCS.hssa (See <<appendix_a>>). 
+per-hart control sub-structure THCS.hssa (See <<appendix_a>>).
 <<dep_conversion>> shows this canonical flow.
 
 Beyond the basic operation described above, the following different
@@ -510,7 +510,7 @@ address translation table (hgatp). The TSM must track memory assignment of
 TVMs (by the untrusted OS/VMM) to ensure memory assignment is
 non-overlapping, along with additional security requirements. The security
 requirements/invariants for enforcement of the memory
-access-control for memory assigned to the TVMs is described in 
+access-control for memory assigned to the TVMs is described in
 <<TVM memory management>>.
 
 === TVM Execution

--- a/src/refarch.adoc
+++ b/src/refarch.adoc
@@ -513,7 +513,7 @@ requirements/invariants for enforcement of the memory
 access-control for memory assigned to the TVMs is described in
 <<TVM memory management>>.
 
-=== TVM Execution
+=== TVM Memory Access
 
 As described above, TVMs can access both classes of memory: (1) confidential
 memory
@@ -526,7 +526,7 @@ confidential memory is using memory encryption (instead or in addition), the
 encryption keys used for confidential memory must be different from
 non-confidential memory.
 
-All TVM memory is mapped in the second-stage page tables controlled by the
+All TVM memory is mapped in the G-stage page tables controlled by the
 TSM explicitly. CoVE implementations that support dynamic conversions between
 confidential
 and non-confidential memory might delegate the allocation of memory for the
@@ -537,7 +537,7 @@ By default any memory mapped to a TVM is confidential. A TVM may then
 explicitly request that
 confidential memory be converted to non-confidential memory regions using
 services provided by the TSM. More
-information about TVM Execution and the lifecycle of a TVM is described in
+information about TVM execution and the lifecycle of a TVM is described in
 the <<TVM Lifecycle>> section of this document.
 
 === Debug and Performance Monitoring

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -448,14 +448,14 @@ remove the confidential pages.
 This requires the host to make three separate ECALLs to the TSM:
 
 . `sbi_covh_tvm_invalidate_pages()`
-. `tee_host_tvm_initiate_fence()`
+. `sbi_covh_tvm_fence()`
 . `sbi_covh_tvm_remove_pages()`
 
 Upon completion of the invalidation of references to confidential memory, the
 host may reclaim the confidential pages that were previously mapped in the
-region using `tee_host_tsm_reclaim_pages()`. The host must then continue the
+region using `sbi_covh_reclaim_pages()`. The host must then continue the
 TVM execution and insert shared pages into the region using
-`tee_host_tvm_add_shared_pages()` on the page-fault when TVM tries to access
+`sbi_covh_add_tvm_shared_pages()` on the page-fault when TVM tries to access
 the region. If the region of address space is unpopulated, the page removal
 ECALLs are not needed and the host can insert shared pages into the region on
 the next page-fault.

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -1301,7 +1301,7 @@ mapping. The GPA of the page mapped is part of the measurement operation.
 The measurement process is a state machine that must be faithfully reproduced
 by the VMM otherwise, the attestation evidence verification by the relying party
 will fail and the TVM will not be considered trustworthy by the relying party.
-The caller must follow ascending order when adding measured pages to a TVM.
+The caller must add pages to a TVM in ascending guest physical order.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -2589,7 +2589,7 @@ faithfully reproduce the state machine for the measurement process otherwise
 the attestation
 evidence verification by the relying party will fail and the TVM will not be
 considered trustworthy.
-The caller must follow ascending order when adding measured pages to a TVM.
+The caller must add pages to a TVM in ascending guest physical order.
 
 | <<sbi_covh_add_tvm_zero_pages, sbi_covh_add_tvm_zero_pages>> | Add a
 zero page for an existing mapping for a TVM page (post initialization).

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -1301,6 +1301,7 @@ mapping. The GPA of the page mapped is part of the measurement operation.
 The measurement process is a state machine that must be faithfully reproduced
 by the VMM otherwise, the attestation evidence verification by the relying party
 will fail and the TVM will not be considered trustworthy by the relying party.
+The caller must follow ascending order when adding measured pages to a TVM.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -2588,6 +2589,7 @@ faithfully reproduce the state machine for the measurement process otherwise
 the attestation
 evidence verification by the relying party will fail and the TVM will not be
 considered trustworthy.
+The caller must follow ascending order when adding measured pages to a TVM.
 
 | <<sbi_covh_add_tvm_zero_pages, sbi_covh_add_tvm_zero_pages>> | Add a
 zero page for an existing mapping for a TVM page (post initialization).

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -987,7 +987,7 @@ struct sbiret sbi_covh_create_tvm(unsigned long tvm_create_params_addr,
                                       unsigned long tvm_create_params_len);
 -----
 Creates a confidential TVM using the specified parameters. The
-`tvm_create_params_addr` is the physical address of the buffer containing the
+`tvm_create_params_addr` is the host physical address of the buffer containing the
 `tvm_create_params` structure described below, and `tvm_create_params_len` is
 the size of the structure in bytes.
 
@@ -1004,12 +1004,12 @@ information about the parameters that should be used to populate
 ----
 struct tvm_create_params {
     /*
-     * The base physical address of the 16 KiB confidential memory region
+     * The host physical address of the 16 KiB confidential memory region
      * that should be used for the TVM's page directory. Must be 16 KiB-aligned.
      */
     unsigned long tvm_page_directory_addr;
     /*
-     * The base physical address of the confidential memory region to be used
+     * The host physical address of the confidential memory region to be used
      * to hold the TVM's state. Must be page-aligned and the number of
      * pages must be at least the value returned in tsm_info.vm_state_pages
      * returned by the call to sbi_covh_get_tsm_info().
@@ -1065,9 +1065,9 @@ Transitions the TVM specified by `tvm_guest_id` from the `TVM_INITIALIZING`
 state to a `TVM_RUNNABLE` state. Also, sets the entry point (`ENTRY_PC`) using
 `entry_sepc` and boot argument (`ENTRY_ARG`) using `entry_arg` for the boot
 vCPU. Both `entry_sepc` and `entry_arg` are included in the measurement
-of the TVM. `entry_sepc` is the address in TVM binary to start the boot vCPU
-from and `entry_arg` is the address of guest flattened device tree (FDT) and is
-passed as an argument to the boot vCPU in `a1` GPR.
+of the TVM. `entry_sepc` is the guest physical address to start the boot vCPU
+from and `entry_arg` is the guest physical address of guest flattened device
+tree (FDT) and is passed as an argument to the boot vCPU in `a1` GPR.
 
 `tvm_identity_addr` points to a 64-bytes buffer containing a host-defined TVM
 identity. This piece of data can be used to bind TVMs to a host-defined identity
@@ -1138,7 +1138,7 @@ The `tap_addr` is the 8-bytes aligned guest physical address of the
 `TVM attestation payload` used for local attestation.
 For VMs that do not require local attestation (only the remote attestation),
 `tap_addr` must be set to `0`.
-The `entry_sepc` is the address at which the vCPU execution will resume.
+The `entry_sepc` is the guest physical address at which the vCPU execution will resume.
 `tvm_identity_addr` is an optional, when set, it points to a 64-bytes buffer
 containing a host-defined TVM identity, see `sbi_covh_finalize_tvm()` for more
 details.
@@ -1220,7 +1220,7 @@ struct sbiret sbi_covh_add_tvm_memory_region(unsigned long tvm_guest_id,
                                                  unsigned long tvm_gpa_addr,
                                                  unsigned long region_len);
 -----
-Marks the range of TVM physical address space starting at `tvm_gpa_addr` as
+Marks the range of TVM's guest physical address space starting at `tvm_gpa_addr` as
 reserved for the mapping of confidential memory. The memory region length is
 specified by `region_len`.
 
@@ -1286,7 +1286,7 @@ struct sbiret sbi_covh_add_tvm_measured_pages(unsigned long tvm_guest_id,
 -----
 Copies `num_pages` pages from non-confidential memory at `source_address` to
 confidential memory at `dest_address`, then measures and maps the pages at
-`dest_address` at the TVM physical address space at `tvm_guest_gpa`. The mapping
+`dest_address` at the TVM's guest physical address space at `tvm_guest_gpa`. The mapping
 must lie within a region of confidential memory created with
 `sbi_covh_add_tvm_memory_region()`. The tsm_page_type parameter must be a legal
 value for enum type `tsm_page_type`.
@@ -1577,7 +1577,7 @@ struct sbiret sbi_covh_tvm_invalidate_pages(unsigned long tvm_guest_id,
                                             unsigned long length);
 -----
 
-Invalidates the pages in the specified range of guest physical address space
+Invalidates the pages in the specified range of TVM's guest physical address space
 and thus marks the
 pages as blocked from any further TVM accesses.
 
@@ -1697,7 +1697,7 @@ The format and semantics of the `tvm_aia_params_addr` structure appears below.
 -------
 struct tvm_aia_params {
     /*
-     * The base address of the virtualized IMSIC in TVM physical address space.
+     * The base address of the virtualized IMSIC in TVM's guest physical address space.
      *
      * IMSIC addresses follow the below pattern:
      *
@@ -2030,7 +2030,7 @@ to EID, `a6` set to FID (see <<cove-fid>>), `a0`-`a5` set to ECALL args.
 struct sbiret sbi_covg_add_mmio_region(unsigned long tvm_gpa_addr,
                                        unsigned long region_len);
 -------
-Marks the specified range of TVM physical address space starting at
+Marks the specified range of TVM's guest physical address space starting at
 `tvm_gpa_addr` as used for emulated MMIO. Upon return, all accesses by the TVM
 within the range are trapped and may be emulated by the host.
 
@@ -2057,7 +2057,7 @@ resume of execution.
 struct sbiret sbi_covg_remove_mmio_region(unsigned long tvm_gpa_addr,
                                           unsigned long region_len);
 -------
-Removes the specified range of TVM physical address space starting at
+Removes the specified range of TVM's guest physical address space starting at
 `tvm_gpa_addr` from the emulated MMIO regions. Upon return, all accesses by the
 TVM within the range will result in a page fault.
 
@@ -2084,7 +2084,7 @@ resume of execution.
 struct sbiret sbi_covg_share_memory_region(unsigned long tvm_gpa_addr,
                                                 unsigned long region_len);
 -------
-Initiates the assignment-change of TVM physical address space starting at
+Initiates the assignment-change of TVM's guest physical address space starting at
 `tvm_gpa_addr` from confidential to non-confidential/shared memory. The
 requested range must lie within an existing region of confidential address
 space, and may or may not be populated. This ECALL results in an exit to the TSM
@@ -2134,7 +2134,7 @@ resume of execution.
 struct sbiret sbi_covg_unshare_memory_region(unsigned long tvm_gpa_addr,
                                              unsigned long region_len);
 -------
-Initiates the assignment-change of TVM physical address space starting at
+Initiates the assignment-change of TVM's guest physical address space starting at
 `tvm_gpa_addr` from
 shared to confidential. The requested range must lie within an existing region
 of non-confidential
@@ -2385,18 +2385,18 @@ If the `sbi_covg_get_attcaps` enumerates attestation services provided by
 the TSM, then this intrinsic is used by a TVM to get an attestation evidence to
 report to a remote relying party.
 
-This intrisic returns an attestation certificate at the address passed as its
-fifth argument (`cert_addr_out`). The certificate is signed by the TSM
+This intrisic returns an attestation certificate at the guest physical address
+passed as its fifth argument (`cert_addr_out`). The certificate is signed by the TSM
 attestation key, and includes the TVM attestation evidence. The TSM attestion
 key is also included in the reported TSM token.
 
-The caller passes the TVM public key address as the first argument
+The caller passes the TVM public key's guest physical address as the first argument
 (`pub_key_addr`). This key will be included in the generated certificate and
 represents the TSM-certified TVM identity.
 
-The third argument (`challenge_data_addr`) points to the attestation challenge
-blob, typically a relying party generated nonce used for demonstrating the
-attestation evidence fresheness.
+The third argument (`challenge_data_addr`) is a guest physical address of
+the attestation challenge blob, typically a relying party generated nonce used
+for demonstrating the attestation evidence fresheness.
 
 The fourth argument (`cert_format`) is the caller's selected attestation
 certificate format. This must be one of the supported
@@ -2554,7 +2554,7 @@ may not be entered after this point. The VMM may start reclaiming TVM
 memory after this point.
 
 | <<sbi_covh_add_tvm_memory_region, sbi_covh_add_tvm_memory_region>> | Adds a
-memory region to the TVM at the specified range of guest physical address space.
+memory region to the TVM at the specified range of TVM's guest physical address space.
 The memory range is confidential to the guest and may only be populated with
 confidential pages.
 
@@ -2569,7 +2569,7 @@ the
 given number of pages from non-confidential memory at `source_address` to
 confidential
 memory at `dest_address`, then measures and maps the pages at `dest_address` in
-the TVM physical
+the guest physical
 address space at `tvm_guest_gpa`. The mapping must lie within a region of
 confidential memory
 created with `sbi_covh_add_tvm_memory_region()`. This call must not be made
@@ -2597,7 +2597,7 @@ This operation adds a zero page into a mapping and keeps the mapping as
 pending, i.e., access from the TVM will fault until the TVM accepts that GPA.
 
 | <<sbi_covh_add_tvm_shared_pages, sbi_covh_add_tvm_shared_pages>> | Maps
-the given number of pages of non-confidential memory into the TVM's physical
+the given number of pages of non-confidential memory into the guest physical
 address space.
 The guest physical address must lie within a region of non-confidential memory
 previously
@@ -2620,8 +2620,8 @@ verifies if the operation is performed in the right state for that
 virtual hart.
 
 | <<sbi_covh_tvm_fence, sbi_covh_tvm_fence>> | Initiates a TLB invalidation
-sequence for all pages that have been invalidated in the given TVM's address
-space
+sequence for all pages that have been invalidated in the given guest physical
+address space
 since the previous call to `sbi_covh_tvm_fence()`. The TLB invalidation
 sequence is
 completed when all vCPUs in the TVM that were running before the call to
@@ -2630,7 +2630,7 @@ cause by sending an IPI to the physical CPUs on which the TVM's vCPUs are
 running.
 
 | <<sbi_covh_tvm_invalidate_pages, sbi_covh_tvm_invalidate_pages>> |
-Invalidates the pages in the specified range of guest physical address space
+Invalidates the pages in the specified range of TVM's guest physical address space
 and thus marks the
 pages as blocked from any further TVM accesses. Guest page faults taken by the
 TVM on invalidated
@@ -2733,13 +2733,13 @@ interrupt files. Must be called from the same physical CPU as
 |===
 
 | <<sbi_covg_add_mmio_region, sbi_covg_add_mmio_region>> |
-Marks the specified range of TVM physical address space starting at
+Marks the specified range of TVM's guest physical address space starting at
 `tvm_gpa_addr` as used for emulated
 MMIO. Upon return, all accesses by the TVM within the range are trapped and may
 be emulated by the host.
 
 | <<sbi_covg_remove_mmio_region, sbi_covg_remove_mmio_region>> |
-Removes the specified range of TVM physical address space starting at
+Removes the specified range of TVM's guest physical address space starting at
 `tvm_gpa_addr` from the emulated
 MMIO regions. Upon return, all accesses by the TVM within the range will result
 in a page fault.

--- a/src/swlifecycle.adoc
+++ b/src/swlifecycle.adoc
@@ -63,13 +63,13 @@ pages added to the TVM, the VMM must invoke `sbi_covh_add_tvm_measured_pages()`
 which extends the initial measurement hash of the TVM. The hash will be used by
 the TSM to generate the attestation report (evidence) when requested by a
 challenger (relying party).
-The VMM must follow ascending order when adding measured pages to a TVM.
+The VMM must add pages to a TVM in ascending guest physical order.
 Note that if the measurement steps are executed by
 the VMM in an incorrect order the final measurements will be different and
 flagged during attestation. In the initial set of measured TVM pages, the VMM
 would typically provide the guest firmware, boot loader and boot kernel as well
 as memory needed for the boot stack, heap and memory tracking structures. During
-`sbi_covh_add_tvm_measured_pages()` & `sbi_covh_add_tvm_zero_pages()`, the
+`sbi_covh_add_tvm_measured_pages()` and `sbi_covh_add_tvm_zero_pages()`, the
 memory granted is tracked by the TSM to ensure that pages assigned to a TVM may
 not be assigned to a non-confidential VM or another TVM. The pages may be lazily
 added to the TVM subsequent to the TVM execution using the

--- a/src/swlifecycle.adoc
+++ b/src/swlifecycle.adoc
@@ -56,8 +56,8 @@ monitoring capabilities enabled etc.
 The VMM may assign memory to the TVM via a sequence of
 `sbi_covh_add_tvm_page_table_pages()` `sbi_covh_add_tvm_measured_pages()` and
 `sbi_covh_add_tvm_zero_pages()` - the former grants memory pages that are to
-contain second-stage paging structures entries that translate a TVM guest
-physical address to the system physical address, while the latter two are used
+contain G-stage paging structures entries that translate a TVM's guest
+physical address to the host physical address, while the latter two are used
 to hold TVM data and are referenced by the hgatp leaf page table entries. For
 pages added to the TVM, the VMM must invoke `sbi_covh_add_tvm_measured_pages()`
 which extends the initial measurement hash of the TVM. The hash will be used by
@@ -110,7 +110,7 @@ specific TVM (identified by the unique identifier). This TEECALL traps into
 the TSM-driver which affects the context switch to the TSM. The TSM then
 manages the activation of the virtual hart on the calling physical hart. During
 this activation the TCB's firmware can enforce that
-stale TLB entries that govern guest physical to system physical page access
+stale TLB entries that govern guest physical to host physical page access
 have been evicted across all hart TLBs. There may also be TLB flushes for
 the virtual-harts due to VS-stage translation changes (guest virtual to
 guest physical) performed by the TVM OS - these are initiated by the TVM OS
@@ -128,7 +128,7 @@ isolation for confidential memory accessed by the TVM software - the
 following hardware enforcement is recommended to address the threat model
 described in <<Architecture Overview and Threat Model>>:
 
-* TVM instruction fetches and page walks (both VS/second-stage and
+* TVM instruction fetches and page walks (both VS/G-stage and
 G/VS-stage) are implicitly enforced to be in confidential memory. This
 requires that the TVM supervisor code should not locate VS-stage page
 tables in non-confidential memory. The TSM enforces that G-stage page
@@ -221,17 +221,17 @@ memory access-control for memory assigned to the TVMs. These rules are enforced
 by the TSM and the CPU MMU:
 
 . Contents of a TVM page assigned (initially measured or lazy-initialized)
-to the TVM is bound to the Guest physical address (GPA) assigned to the TVM
+to the TVM is bound to the guest physical address (GPA) assigned to the TVM
 during TVM operation.
 . A TVM page can only be assigned to a single TVM, and mapped via a single
 GPA unless aliases are allowed in which case, such aliases must be tracked
-by the TSM. Aliases in the virtual address space are under the purview of
+by the TSM. Aliases in the guest virtual address space are under the purview of
 the TVM OS.
 . VS-stage address translation - A TVM page mapping must be translated
 only via VS-stage translation structures which are contained in pages
 assigned to the same TVM.
 . G-stage address translation:
-  .. A TVM page guest physical address mapping must be translated only via
+  .. A TVM page's guest physical address mapping must be translated only via
 the TSM-managed G-stage translation structures for that TVM.
   .. G-stage structures must not be shared between TVMs, and must not
 refer to any other TVMs pages.
@@ -289,7 +289,7 @@ Any caching of the address translation information when the memory tracking for
 confidential memory is enabled must cache whether the address translation is for
 a TEE context or not. A miss in the cached address translation information is
 expected to cause a lookup of the address translation structure using the
-physical address (PA) and the resolved page size for TEE access evaluation -
+host physical address and the resolved page size for TEE access evaluation -
 which results in the TEE access information that is cached.
 
 In CoVE implementations with MTT, the MTT lookups are performed using the
@@ -441,7 +441,7 @@ This section refers to CoVE implementations supporting OS/VMM-initiated page
 assignment to a TVM.
 
 The VMM uses this operation to add a hgatp structure page to be used for mapping
-a guest physical address (GPA) to a physical address (PA). The inputs to this
+a guest physical address (GPA) to a host physical address (HPA). The inputs to this
 operation are the TVM identifier and the physical address(es) for the new
 page(s) to be used for the hgatp structure entries
 
@@ -473,13 +473,13 @@ TVM (initial) measurement.
 
 If the contents of the page are not specified, which is allowed
 post-finalization of the TVM, the TSM zero's the page during initialization. The
-guest physical address (GPA) to the selected page physical address (PA) is
+guest physical address (GPA) to the selected host physical address (HPA) is
 specified in the add operation by the VMM. The TSM verifies that a free guest
 page mapping must exist for this operation to succeed. Effectively, this
 operation sets up the properties of the HGATP L0 leaf entry for the PA.
 
-The inputs to this operation are: TVM identifier, physical address for the new
-page to be assigned to the TVM, source physical address for the source of the
+The inputs to this operation are: TVM identifier, host physical address for the new
+page to be assigned to the TVM, source host physical address for the source of the
 page contents to be loaded for the TVM (and measured by the TSM), and the GPA
 and page size to be used for the guest mapping to be added.
 
@@ -650,7 +650,7 @@ file it was using is available for OS/VMM use.
 
 While a TVM virtual hart is unbound, MSIs directed at the virtual hart shall
 trigger the notice interrupt registered in tvm_vhart_aia_init. Attempts by other
-TVM virtual harts to write the virtual hart's IMSIC in the guest physical
+TVM virtual harts to write the virtual hart's IMSIC in the TVM's guest physical
 address space (e.g., for the purposes of generating an IPI) shall generate a
 guest page fault exit on the virtual hart which initiated the write.
 

--- a/src/swlifecycle.adoc
+++ b/src/swlifecycle.adoc
@@ -62,7 +62,9 @@ to hold TVM data and are referenced by the hgatp leaf page table entries. For
 pages added to the TVM, the VMM must invoke `sbi_covh_add_tvm_measured_pages()`
 which extends the initial measurement hash of the TVM. The hash will be used by
 the TSM to generate the attestation report (evidence) when requested by a
-challenger (relying party). Note that if the measurement steps are executed by
+challenger (relying party).
+The VMM must follow ascending order when adding measured pages to a TVM.
+Note that if the measurement steps are executed by
 the VMM in an incorrect order the final measurements will be different and
 flagged during attestation. In the initial set of measured TVM pages, the VMM
 would typically provide the guest firmware, boot loader and boot kernel as well

--- a/src/swlifecycle.adoc
+++ b/src/swlifecycle.adoc
@@ -6,7 +6,7 @@
 This section describes the TEEI operations for the lifecycle of a TVM
 including the OS/VMM interactions with the TSM.
 
-=== TVM build and initialization
+=== TVM Creation
 
 The host OS/VMM should be capable of hosting many TVMs on a CoVE-capable
 platform (limited only by the practical limits of the number of CPUs and


### PR DESCRIPTION
Minor (non-controversial) changes to the spec that fix #100 #103 #104 #111 #128 


A pass to unify nomenclature:

* System physical address -> host physical address
* physical address (when referred to HPA) -> host physical address
* TVM physical address space -> TVM's guest physical address space
* guest physical address space -> TVM's guest physical address space 
* Make it clear in ABI whether the address is GPA or HPA
* Second-stage address translation -> G-stage address translation
* second-stage paging structures -> G-stage paging structures

There are still some unclear address definitions in the AIA sections.