### PR TITLE
sbi_cove: initial version of memory mappings

### DIFF
--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -138,9 +138,148 @@ partitioning of confidential and non-confidential memory (for example
 execution of untrusted code, and thus do not need to implement above ABI.
 ====
 
+===== Memory states and transitions
+The memory management is described in terms of two parallel state machines that
+track the ownership and mapping of every physical memory range.
+
+* The *HPA* (host physical address) state machine tracks who owns a given
+  physical page on the platform.
+* The *GPA* (guest physical address) state machine tracks how a page slot in
+  a particular TVM's guest physical address space is currently used.
+
+The ecall specifications annotate every transition with a `*HPA transitions:*`
+and/or `*GPA transitions:*` line referring to the state names defined here.
+
+The HPA states are caller-observable types of physical pages; how the TSM
+internally encodes them is implementation-defined. GPA states are per-TVM:
+a GPA state transition for one TVM has no effect on the GPA space of another
+TVM, but it does constrain which HPA states may back that GPA.
+
+These state machines cover physical pages and GPA ranges manipulated through
+the CoVE host and guest interfaces. On platforms with dynamic conversion,
+assignable pages typically begin in `VMM`. On statically partitioned platforms,
+some assignable pages may instead begin already confidential and participate
+only in the `UNASSIGNED`, `TSM(gid)`, or `TVM(gid)` side of the model.
+
+*Notation.* `TSM(gid)`, `TVM(gid)` and `SHARED(gid)` denote per-TVM association,
+where `gid` is the TVM's `tvm_guest_id`. `INVALIDATING(prev)` and
+`INVALIDATED(prev)` are parameterized over the GPA state `prev` that the slot
+was in before invalidation was started; `tvm_validate_pages()` returns the
+slot to `prev`, while `tvm_remove_pages()` consumes an `INVALIDATED(prev)`
+slot.
+
+A confidential page associated with a TVM is bound to exactly one `tvm_guest_id`
+until the page is explicitly removed from that TVM or the TVM is destroyed.
+
+A HPA range used in CoVE interfaces is only ever accessible by up to a single
+VMM and up to a single TSM.
+
+====== HPA states
+
+* `VMM`           -- non-confidential memory, accessible only by VMM.
+* `CONVERTING`    -- in-flight conversion.
+* `UNASSIGNED`    -- confidential, not currently assigned to any TVM.
+* `TSM(gid)`      -- confidential, private to TSM and related to TVM `gid`
+                    (TVM control structure, page-table pool, vCPU state
+                    pages, ...).
+* `TVM(gid)`      -- confidential, mapped into TVM `gid`'s GPA.
+* `SHARED(gid)`   -- non-confidential, mapped into VMM's HPA and TVM `gid`'s GPA.
+* `ILLEGAL`       -- Not usable in the CoVE SBI.
+
+[plantuml]
+....
+@startuml
+hide empty description
+state "TSM(gid)" as TSM_GID
+state "TVM(gid)" as TVM_GID
+state "SHARED(gid)" as SHARED_GID
+state ILLEGAL
+VMM        --> CONVERTING : sbi_covh_convert_pages()
+CONVERTING --> UNASSIGNED : sbi_covh_global_fence() +\nsbi_covh_local_fence()
+UNASSIGNED --> VMM        : sbi_covh_reclaim_pages()
+UNASSIGNED --> TSM_GID    : sbi_covh_create_tvm(),\nsbi_covh_promote_to_tvm()\n,\nsbi_covh_add_tvm_page_table_pages(),\nsbi_covh_create_tvm_vcpu()
+UNASSIGNED --> TVM_GID    : sbi_covh_promote_to_tvm()\n,\nsbi_covh_add_tvm_measured_pages(),\nsbi_covh_add_tvm_zero_pages()
+VMM        --> SHARED_GID : sbi_covh_add_tvm_shared_pages()
+TVM_GID    --> UNASSIGNED : sbi_covh_destroy_tvm(),\nsbi_covh_tvm_remove_pages()
+TSM_GID    --> UNASSIGNED : sbi_covh_destroy_tvm()
+SHARED_GID --> VMM        : sbi_covh_destroy_tvm(),\nsbi_covh_tvm_remove_pages()
+VMM -[hidden]-> ILLEGAL
+@enduml
+....
+
+====== GPA states
+
+* `UNMAPPED`         -- the GPA is not part of any defined region.
+* `MMIO`             -- declared as an MMIO region by the guest;
+                        accesses forwarded to VMM.
+* `MAPPABLE`         -- confidential region declared by the host; no page mapped.
+* `MAPPED`           -- a confidential page is present at this GPA.
+* `SHAREABLE`        -- declared as shareable by the guest; no page mapped.
+* `SHARED`           -- a non-confidential shared page is mapped at this GPA.
+* `MAPPED_SHAREABLE` -- a confidential page is mapped at a GPA that the guest
+                        has declared as shareable.
+* `UNSHARED`         -- previously `SHARED`, the guest has declared the GPA
+                        as unshareable.
+* `INVALIDATING(x)`  -- invalidation started from previous state `x`
+* `INVALIDATED(x)`   -- invalidation completed by `tvm_fence`
+
+[plantuml]
+....
+@startuml
+hide empty description
+
+state "INVALIDATING(SHARED)" as INVALIDATING_SHARED
+state "INVALIDATING(MAPPED)" as INVALIDATING_MAPPED
+state "INVALIDATING(MAPPED_SHAREABLE)" as INVALIDATING_MAPPED_SHAREABLE
+state "INVALIDATING(UNSHARED)" as INVALIDATING_UNSHARED
+state "INVALIDATED(SHARED)" as INVALIDATED_SHARED
+state "INVALIDATED(MAPPED)" as INVALIDATED_MAPPED
+state "INVALIDATED(MAPPED_SHAREABLE)" as INVALIDATED_MAPPED_SHAREABLE
+state "INVALIDATED(UNSHARED)" as INVALIDATED_UNSHARED
+
+UNMAPPED         --> MMIO             : sbi_covg_add_mmio_region()
+MMIO             --> UNMAPPED         : sbi_covg_remove_mmio_region()
+
+UNMAPPED         --> MAPPABLE         : sbi_covh_add_tvm_memory_region()
+MAPPABLE         --> MAPPED           : sbi_covh_add_tvm_measured_pages(),\nsbi_covh_add_tvm_zero_pages()
+MAPPABLE         --> SHAREABLE        : sbi_covg_share_memory_region()
+MAPPED           --> MAPPED_SHAREABLE : sbi_covg_share_memory_region()
+SHAREABLE        --> SHARED           : sbi_covh_add_tvm_shared_pages()
+SHARED           --> UNSHARED         : sbi_covg_unshare_memory_region()
+SHAREABLE        --> MAPPABLE         : sbi_covg_unshare_memory_region()
+MAPPED_SHAREABLE --> MAPPED           : sbi_covg_unshare_memory_region()
+
+SHARED           --> INVALIDATING_SHARED           : sbi_covh_tvm_invalidate_pages()
+MAPPED           --> INVALIDATING_MAPPED           : sbi_covh_tvm_invalidate_pages()
+MAPPED_SHAREABLE --> INVALIDATING_MAPPED_SHAREABLE : sbi_covh_tvm_invalidate_pages()
+UNSHARED         --> INVALIDATING_UNSHARED         : sbi_covh_tvm_invalidate_pages()
+
+INVALIDATING_SHARED           --> INVALIDATED_SHARED           : sbi_covh_tvm_fence()
+INVALIDATING_MAPPED           --> INVALIDATED_MAPPED           : sbi_covh_tvm_fence()
+INVALIDATING_MAPPED_SHAREABLE --> INVALIDATED_MAPPED_SHAREABLE : sbi_covh_tvm_fence()
+INVALIDATING_UNSHARED         --> INVALIDATED_UNSHARED         : sbi_covh_tvm_fence()
+
+INVALIDATING_SHARED           --> SHARED           : sbi_covh_tvm_validate_pages()
+INVALIDATING_MAPPED           --> MAPPED           : sbi_covh_tvm_validate_pages()
+INVALIDATING_MAPPED_SHAREABLE --> MAPPED_SHAREABLE : sbi_covh_tvm_validate_pages()
+INVALIDATING_UNSHARED         --> UNSHARED         : sbi_covh_tvm_validate_pages()
+INVALIDATED_SHARED            --> SHARED           : sbi_covh_tvm_validate_pages()
+INVALIDATED_MAPPED            --> MAPPED           : sbi_covh_tvm_validate_pages()
+INVALIDATED_MAPPED_SHAREABLE  --> MAPPED_SHAREABLE : sbi_covh_tvm_validate_pages()
+INVALIDATED_UNSHARED          --> UNSHARED         : sbi_covh_tvm_validate_pages()
+
+INVALIDATED_MAPPED            --> MAPPABLE         : sbi_covh_tvm_remove_pages()
+INVALIDATED_UNSHARED          --> MAPPABLE         : sbi_covh_tvm_remove_pages()
+INVALIDATED_MAPPED_SHAREABLE  --> SHAREABLE        : sbi_covh_tvm_remove_pages()
+INVALIDATED_SHARED            --> SHAREABLE        : sbi_covh_tvm_remove_pages()
+@enduml
+....
+
 ===== Converting non-confidential memory to confidential memory
-Platform memory is non-confidential by default, and must be converted to
-confidential memory before use with TVMs. The conversion process is initiated by
+Pages that are currently in `VMM` must be converted to confidential memory
+before use with TVMs. On platforms with static partitioning, pages that already
+start confidential do not require this sequence and may not support the
+conversion or reclamation ECALLs. The conversion process is initiated by
 designating the host physical pages that are to be converted, and then issuing
 fence operations to ensure that all outstanding TLB entries to the
 non-confidential memory are flushed across all CPUs/harts on the platform. This
@@ -897,6 +1036,7 @@ page size is 4 KiB.
 
 The `base_page_address` must be page-aligned.
 
+*HPA transitions:* base_page_address: VMM -> CONVERTING
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -923,6 +1063,8 @@ Reclaims `num_pages` of confidential memory starting at `base_page_address`.
 The pages must not be currently assigned to an active TVM. The implied page
 size is 4 KiB.
 
+*HPA transitions:* base_page_address: UNASSIGNED -> VMM
+
 The possible error codes returned in `sbiret.error` are shown below.
 
 [#table_tee_tsm_reclaim_pages_errors]
@@ -946,6 +1088,8 @@ Initiates a TLB invalidation sequence for all pages marked for conversion via
 calls to `sbi_covh_convert_pages()`. The TLB invalidation sequence is completed
 when `sbi_covh_local_fence()` has been invoked on all other CPUs. An error is
 returned if a TLB invalidation sequence is already in progress.
+
+*HPA transitions:* Upon completion of the whole sequence: CONVERTING -> UNASSIGNED
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -1000,6 +1144,7 @@ Callers of this API should first invoke `sbi_covh_get_tsm_info()` to obtain
 information about the parameters that should be used to populate
 `tvm_create_params`.
 
+
 [source, C]
 ----
 struct tvm_create_params {
@@ -1026,6 +1171,8 @@ success, the TVM will be in the `TVM_INITIALIZING` state, until a subsequent
 call to
 `sbi_covh_finalize_tvm()` is made to transition the TVM to a `TVM_RUNNABLE`
 state.
+
+*HPA transitions:* tvm_create_params_addr: UNASSIGNED -> TSM(tvm_guest_id)
 
 The list of possible TVM states appears below.
 
@@ -1166,6 +1313,10 @@ VM's data and the page tables. After this call, the OS/VMM must interact with
 this TVM via the TSM using the COVH ABI, i.e., resuming the TVM using the
 `sbi_covh_run_tvm_vcpu()` call.
 
+*HPA transitions:*
+pages referenced by hgatp leaves: UNASSIGNED -> TVM(tvm_guest_id);
+other pages: UNASSIGNED -> TSM(tvm_guest_id)
+
 If the call fails, the TSM returns the SBI error code in `sbiret.error` to the
 OS/VMM. The possible error codes are shown below.
 
@@ -1202,6 +1353,11 @@ succeeds.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
+*HPA transitions:*
+TVM(tvm_guest_id) -> UNASSIGNED;
+TSM(tvm_guest_id) -> UNASSIGNED;
+SHARED(tvm_guest_id) -> VMM
+
 [#table_sbi_covh_destroy_tvm_errors]
 .COVE Host Destroy TVM Errors
 [cols="2,3", width=90%, align="center", options="header"]
@@ -1230,6 +1386,8 @@ calling `sbi_covh_finalize_tvm()`.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
+*GPA transitions:* tvm_gpa_addr: UNMAPPED -> MAPPABLE
+
 [#table_sbi_covh_add_tvm_memory_region_errors]
 .COVE Host Add TVM Memory Region
 [cols="2,3", width=90%, align="center", options="header"]
@@ -1256,6 +1414,8 @@ TVM's page-table page-pool. The implied page size is 4 KiB.
 
 Page table pages may be added at any time, and a typical use case is in
 response to a TVM page fault.
+
+*HPA transitions:* UNASSIGNED -> TSM(tvm_guest_id)
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -1304,6 +1464,10 @@ will fail and the TVM will not be considered trustworthy by the relying party.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
+*HPA transitions:* source_address: VMM; dest_address: UNASSIGNED -> TVM(tvm_guest_id)
+
+*GPA transitions:* tvm_guest_gpa: MAPPABLE -> MAPPED
+
 [#table_sbi_covh_add_tvm_measured_pages_errors]
 .COVE Host Add TVM Measured Pages
 [cols="2,3", width=90%, align="center", options="header"]
@@ -1338,6 +1502,10 @@ Zero pages for non-present TVM-specified GPA ranges may be added only post TVM
 finalization, and are typically demand faulted on TVM access.
 
 This call may be made only after calling `sbi_covh_finalize_tvm()`.
+
+*HPA transitions:* base_page_address: UNASSIGNED -> TVM(tvm_guest_id)
+
+*GPA transitions:* tvm_base_page_address: MAPPABLE -> MAPPED
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -1375,6 +1543,10 @@ Shared pages can be added only after the TVM begins execution, and calls the
 TSM to define the location of shared memory regions. They are typically demand
 faulted on TVM access.
 
+*HPA transitions:* base_page_address: VMM -> SHARED(tvm_guest_id)
+
+*GPA transitions:* tvm_base_page_address: SHAREABLE -> SHARED
+
 The possible error codes returned in `sbiret.error` are shown below.
 
 [#table_sbi_covh_add_tvm_shared_pages_errors]
@@ -1403,6 +1575,8 @@ Adds a vCPU with ID `vcpu_id` to the TVM specified by `tvm_guest_id`.
 region used to hold the TVM's vCPU state, and must be
 `tsm_info::tvm_state_pages` pages in length. This call must not be made after
 calling `sbi_covh_finalize_tvm()`.
+
+*HPA transitions:* tvm_state_page_addr: UNASSIGNED -> TSM(tvm_guest_id)
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -1555,6 +1729,8 @@ the physical CPUs on which the TVM's vCPUs are running. Note that the physical
 CPUs don't have to necessarily perform anything on those IPIs. An error is
 returned if a TLB invalidation sequence is already in progress for the TVM.
 
+*GPA transitions:* upon completion of the sequence: forall x. INVALIDATING(x) -> INVALIDATED(x)
+
 The possible error codes returned in `sbiret.error` are shown below.
 
 [#table_sbi_covh_tvm_fence_errors]
@@ -1595,6 +1771,9 @@ to the host.
 The pages remain invalid until the mappings are validated (marked present),
 removed, or become part of a huge page by promotion/demotion operation.
 
+*GPA transitions:* gpa: SHARED -> INVALIDATING(SHARED) or MAPPED -> INVALIDATING(MAPPED)
+or MAPPED_SHAREABLE -> INVALIDATING(MAPPED_SHAREABLE) or UNSHARED -> INVALIDATING(UNSHARED)
+
 The possible error codes returned in `sbiret.error` are shown below.
 
 [#table_sbi_covh_tvm_invalidate_pages_errors]
@@ -1627,6 +1806,8 @@ will mark the pages as present and restore the pages to their previous state.
 This ECALL may be used to revert an in-progress page removal or huge page
 promotion/demotion sequence.
 
+*GPA transitions:* gpa: forall x. INVALIDATING(x) -> x or INVALIDATED(x) -> x
+
 The possible error codes returned in `sbiret.error` are shown below.
 
 [#table_sbi_covh_tvm_validate_pages_errors]
@@ -1653,8 +1834,13 @@ Removes mappings for invalidated pages in the specified range of guest physical
 address space. The range to be unmapped must already have been invalidated and
 fenced, and must lie within a removable region of the guest's physical address
 space. The TSM zeros out all page table entries (PTEs) within the specified
-range and returns the ownership of the pages to the host if previously owned by
-the TVM.
+range. Confidential pages removed from the TVM return to the confidential
+`UNASSIGNED` pool; invalidated shared pages return to `VMM`.
+
+*HPA transitions:* backing page for gpa: TVM(tvm_guest_id) -> UNASSIGNED or SHARED(tvm_guest_id) -> VMM
+
+*GPA transitions:* gpa: INVALIDATED(UNSHARED) -> MAPPABLE or INVALIDATED(MAPPED_SHAREABLE) -> SHAREABLE
+or INVALIDATED(MAPPED) -> MAPPABLE or INVALIDATED(SHARED) -> SHAREABLE
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -2037,6 +2223,8 @@ Both `tvm_gpa_addr` and `region_len` must be 4 KiB-aligned, and the region must
 not overlap with a previously defined region. This call will result in an exit
 to the host on success.
 
+*GPA transitions:* tvm_gpa_addr: UNMAPPED -> MMIO
+
 [#table_sbi_covg_add_mmio_region_errors]
 .COVE Guest Add MMIO Region
 [cols="2,3", width=90%, align="center", options="header"]
@@ -2064,6 +2252,8 @@ Both `tvm_gpa_addr` and `region_len` must be 4 KiB-aligned. The TSM must remove
 every MMIO region that overlaps with the requested range. This call will result
 in an exit to the host on success.
 
+*GPA transitions:* tvm_gpa_addr: MMIO -> UNMAPPED
+
 [#table_sbi_covg_remove_mmio_region_errors]
 .COVE Guest Remove MMIO Region
 [cols="2,3", width=90%, align="center", options="header"]
@@ -2089,7 +2279,10 @@ requested range must lie within an existing region of confidential address
 space, and may or may not be populated. This ECALL results in an exit to the TSM
 which enforces the security properties on the mapping and exits to the VMM
 host. The host then removes any confidential pages already populated in the
-region and inserts non-confidential pages on page-faults.
+region and inserts non-confidential pages on page-faults. For populated ranges,
+the host must invalidate the confidential mappings, complete `sbi_covh_tvm_fence()`,
+and then remove the pages with `sbi_covh_tvm_remove_pages()` before shared
+pages may be inserted.
 
 The calling TVM vCPU is considered blocked until the assignment-change is
 completed. Attempts to run it with `sbi_covh_run_tvm_vcpu()` will fail. Any
@@ -2109,6 +2302,8 @@ request share of multiple smaller memory regions, for example, at the 4 KiB page
 size granularity.
 
 Both `tvm_gpa_addr` and `region_len` must be 4 KiB-aligned.
+
+*GPA transitions:* tvm_gpa_addr: MAPPABLE -> SHAREABLE or MAPPED -> MAPPED_SHAREABLE
 
 The possible error codes returned in sbiret.error are:
 
@@ -2142,13 +2337,18 @@ to the TSM which
 enforces the security properties on the mapping and exits to the OS/VMM. The
 host then removes
 any non-confidential pages already populated in the region and inserts
-confidential pages on page-faults.
+confidential pages on page-faults. For populated ranges, the host must
+invalidate the shared mappings, complete `sbi_covh_tvm_fence()`, and then
+remove the pages with `sbi_covh_tvm_remove_pages()` before confidential pages
+may be inserted.
 
 The calling TVM vCPU is considered blocked until the assignment-change is
 completed. Attempts to run it
 with `sbi_covh_run_tvm_vcpu()` will fail. Any guest page faults taken by other
 TVM vCPUs in the
 invalidated pages continue to be reported to the host.
+
+*GPA transitions:* tvm_gpa_addr: SHARED -> UNSHARED, SHAREABLE -> MAPPABLE, MAPPED_SHAREABLE -> MAPPED
 
 Both `tvm_gpa_addr` and `region_len` must be 4 KiB-aligned.
 
@@ -2806,4 +3006,3 @@ state save and restore of the performance monitoring inhibit and trigger
 controls). The specification of this interface is TBD.
 
 |===
-

--- a/src/sbi_cove.adoc
+++ b/src/sbi_cove.adoc
@@ -162,11 +162,7 @@ some assignable pages may instead begin already confidential and participate
 only in the `UNASSIGNED`, `TSM(gid)`, or `TVM(gid)` side of the model.
 
 *Notation.* `TSM(gid)`, `TVM(gid)` and `SHARED(gid)` denote per-TVM association,
-where `gid` is the TVM's `tvm_guest_id`. `INVALIDATING(prev)` and
-`INVALIDATED(prev)` are parameterized over the GPA state `prev` that the slot
-was in before invalidation was started; `tvm_validate_pages()` returns the
-slot to `prev`, while `tvm_remove_pages()` consumes an `INVALIDATED(prev)`
-slot.
+where `gid` is the TVM's `tvm_guest_id`.
 
 A confidential page associated with a TVM is bound to exactly one `tvm_guest_id`
 until the page is explicitly removed from that TVM or the TVM is destroyed.
@@ -183,7 +179,7 @@ VMM and up to a single TSM.
                     (TVM control structure, page-table pool, vCPU state
                     pages, ...).
 * `TVM(gid)`      -- confidential, mapped into TVM `gid`'s GPA.
-* `SHARED(gid)`   -- non-confidential, mapped into VMM's HPA and TVM `gid`'s GPA.
+* `MUTUAL(gid)`   -- non-confidential, mapped into VMM's HPA and TVM `gid`'s GPA.
 * `ILLEGAL`       -- Not usable in the CoVE SBI.
 
 [plantuml]
@@ -192,86 +188,44 @@ VMM and up to a single TSM.
 hide empty description
 state "TSM(gid)" as TSM_GID
 state "TVM(gid)" as TVM_GID
-state "SHARED(gid)" as SHARED_GID
+state "MUTUAL(gid)" as MUTUAL_GID
 state ILLEGAL
 VMM        --> CONVERTING : sbi_covh_convert_pages()
 CONVERTING --> UNASSIGNED : sbi_covh_global_fence() +\nsbi_covh_local_fence()
 UNASSIGNED --> VMM        : sbi_covh_reclaim_pages()
 UNASSIGNED --> TSM_GID    : sbi_covh_create_tvm(),\nsbi_covh_promote_to_tvm()\n,\nsbi_covh_add_tvm_page_table_pages(),\nsbi_covh_create_tvm_vcpu()
-UNASSIGNED --> TVM_GID    : sbi_covh_promote_to_tvm()\n,\nsbi_covh_add_tvm_measured_pages(),\nsbi_covh_add_tvm_zero_pages()
-VMM        --> SHARED_GID : sbi_covh_add_tvm_shared_pages()
-TVM_GID    --> UNASSIGNED : sbi_covh_destroy_tvm(),\nsbi_covh_tvm_remove_pages()
+UNASSIGNED --> TVM_GID    : sbi_covh_promote_to_tvm(),\nsbi_covh_add_tvm_measured_pages(),\nsbi_covh_add_tvm_zero_pages()
+VMM        --> MUTUAL_GID : sbi_covh_add_tvm_shared_pages()
+TVM_GID    --> UNASSIGNED : sbi_covh_destroy_tvm(),\nsbi_covh_remove_tvm_shared_pages(),\nsbi_covg_share_memory_region()
 TSM_GID    --> UNASSIGNED : sbi_covh_destroy_tvm()
-SHARED_GID --> VMM        : sbi_covh_destroy_tvm(),\nsbi_covh_tvm_remove_pages()
+MUTUAL_GID --> VMM        : sbi_covh_destroy_tvm(),\nsbi_covh_remove_tvm_shared_pages()
 VMM -[hidden]-> ILLEGAL
 @enduml
 ....
 
 ====== GPA states
-
 * `UNMAPPED`         -- the GPA is not part of any defined region.
+* `MAPPABLE`         -- confidential region declared by the host; no page mapped.
+* `MAPPED`           -- a TVM page is mapped at this GPA.
+* `SHAREABLE`        -- declared as shareable by the guest; no page mapped.
+* `SHARED`           -- a TVM or SHARED page is mapped at this GPA.
 * `MMIO`             -- declared as an MMIO region by the guest;
                         accesses forwarded to VMM.
-* `MAPPABLE`         -- confidential region declared by the host; no page mapped.
-* `MAPPED`           -- a confidential page is present at this GPA.
-* `SHAREABLE`        -- declared as shareable by the guest; no page mapped.
-* `SHARED`           -- a non-confidential shared page is mapped at this GPA.
-* `MAPPED_SHAREABLE` -- a confidential page is mapped at a GPA that the guest
-                        has declared as shareable.
-* `UNSHARED`         -- previously `SHARED`, the guest has declared the GPA
-                        as unshareable.
-* `INVALIDATING(x)`  -- invalidation started from previous state `x`
-* `INVALIDATED(x)`   -- invalidation completed by `tvm_fence`
 
 [plantuml]
 ....
 @startuml
 hide empty description
-
-state "INVALIDATING(SHARED)" as INVALIDATING_SHARED
-state "INVALIDATING(MAPPED)" as INVALIDATING_MAPPED
-state "INVALIDATING(MAPPED_SHAREABLE)" as INVALIDATING_MAPPED_SHAREABLE
-state "INVALIDATING(UNSHARED)" as INVALIDATING_UNSHARED
-state "INVALIDATED(SHARED)" as INVALIDATED_SHARED
-state "INVALIDATED(MAPPED)" as INVALIDATED_MAPPED
-state "INVALIDATED(MAPPED_SHAREABLE)" as INVALIDATED_MAPPED_SHAREABLE
-state "INVALIDATED(UNSHARED)" as INVALIDATED_UNSHARED
-
+[*] --> UNMAPPED
 UNMAPPED         --> MMIO             : sbi_covg_add_mmio_region()
 MMIO             --> UNMAPPED         : sbi_covg_remove_mmio_region()
-
 UNMAPPED         --> MAPPABLE         : sbi_covh_add_tvm_memory_region()
 MAPPABLE         --> MAPPED           : sbi_covh_add_tvm_measured_pages(),\nsbi_covh_add_tvm_zero_pages()
 MAPPABLE         --> SHAREABLE        : sbi_covg_share_memory_region()
-MAPPED           --> MAPPED_SHAREABLE : sbi_covg_share_memory_region()
+MAPPED           --> SHAREABLE        : sbi_covg_share_memory_region()
 SHAREABLE        --> SHARED           : sbi_covh_add_tvm_shared_pages()
-SHARED           --> UNSHARED         : sbi_covg_unshare_memory_region()
 SHAREABLE        --> MAPPABLE         : sbi_covg_unshare_memory_region()
-MAPPED_SHAREABLE --> MAPPED           : sbi_covg_unshare_memory_region()
-
-SHARED           --> INVALIDATING_SHARED           : sbi_covh_tvm_invalidate_pages()
-MAPPED           --> INVALIDATING_MAPPED           : sbi_covh_tvm_invalidate_pages()
-MAPPED_SHAREABLE --> INVALIDATING_MAPPED_SHAREABLE : sbi_covh_tvm_invalidate_pages()
-UNSHARED         --> INVALIDATING_UNSHARED         : sbi_covh_tvm_invalidate_pages()
-
-INVALIDATING_SHARED           --> INVALIDATED_SHARED           : sbi_covh_tvm_fence()
-INVALIDATING_MAPPED           --> INVALIDATED_MAPPED           : sbi_covh_tvm_fence()
-INVALIDATING_MAPPED_SHAREABLE --> INVALIDATED_MAPPED_SHAREABLE : sbi_covh_tvm_fence()
-INVALIDATING_UNSHARED         --> INVALIDATED_UNSHARED         : sbi_covh_tvm_fence()
-
-INVALIDATING_SHARED           --> SHARED           : sbi_covh_tvm_validate_pages()
-INVALIDATING_MAPPED           --> MAPPED           : sbi_covh_tvm_validate_pages()
-INVALIDATING_MAPPED_SHAREABLE --> MAPPED_SHAREABLE : sbi_covh_tvm_validate_pages()
-INVALIDATING_UNSHARED         --> UNSHARED         : sbi_covh_tvm_validate_pages()
-INVALIDATED_SHARED            --> SHARED           : sbi_covh_tvm_validate_pages()
-INVALIDATED_MAPPED            --> MAPPED           : sbi_covh_tvm_validate_pages()
-INVALIDATED_MAPPED_SHAREABLE  --> MAPPED_SHAREABLE : sbi_covh_tvm_validate_pages()
-INVALIDATED_UNSHARED          --> UNSHARED         : sbi_covh_tvm_validate_pages()
-
-INVALIDATED_MAPPED            --> MAPPABLE         : sbi_covh_tvm_remove_pages()
-INVALIDATED_UNSHARED          --> MAPPABLE         : sbi_covh_tvm_remove_pages()
-INVALIDATED_MAPPED_SHAREABLE  --> SHAREABLE        : sbi_covh_tvm_remove_pages()
-INVALIDATED_SHARED            --> SHAREABLE        : sbi_covh_tvm_remove_pages()
+SHARED           --> SHAREABLE        : sbi_covh_remove_tvm_shared_pages()
 @enduml
 ....
 
@@ -574,47 +528,17 @@ is that the host will service a subsequent page-fault that results from a
 TVM-access to the non-confidential region.
 
 ===== TVM-defined shared memory regions
-TVMs can choose to yield access to confidential memory at runtime and request
-shared (non-confidential) memory.
-The TVM must communicate its request to the host to convert confidential to
-non-confidential and vice-versa
-explicitly via the `sbi_covg_share_memory_region()` and
-`sbi_covg_unshare_memory_region()`. This request
+TVMs can choose to transfer confidential memory to shared at runtime.
+The TVM must communicate its request via the `sbi_covg_share_memory_region()`
+and `sbi_covg_unshare_memory_region()`. This request
 results in an exit to the TSM which enforces the security properties on the
-mapping and exits to the VMM host.
-If the region of address space is populated, the host must first invalidate and
-remove the confidential pages.
-This requires the host to make three separate ECALLs to the TSM:
+mapping and exits to the VMM host to notify it.
 
-. `sbi_covh_tvm_invalidate_pages()`
-. `tee_host_tvm_initiate_fence()`
-. `sbi_covh_tvm_remove_pages()`
+The TSM clears the memory range before allowing the VMM to access it.
 
-Upon completion of the invalidation of references to confidential memory, the
-host may reclaim the confidential pages that were previously mapped in the
-region using `tee_host_tsm_reclaim_pages()`. The host must then continue the
-TVM execution and insert shared pages into the region using
-`tee_host_tvm_add_shared_pages()` on the page-fault when TVM tries to access
-the region. If the region of address space is unpopulated, the page removal
-ECALLs are not needed and the host can insert shared pages into the region on
-the next page-fault.
-
-The calling TVM vCPU is considered blocked until the assignment-change is
-completed. Attempts to run it with `sbi_covh_run_tvm_vcpu()` will fail.
-Any guest page faults taken by other TVM vCPUs in the invalidated pages
-continue to be reported to the host.
-
-Note that the TVM vCPU is blocked until the host completes the conversion to
-shared memory - this sequence may happen in two parts - invalidation of
-references to confidential memory (and address translation cache flushes if any)
-and, the addition of the mapping to shared memory - the host may run the TVM
-vCPU after the first part, and lazily handle the fault for the second part.
-Also the reclamation is of the confidential pages, and the shared memory pages
-provided by the host may be unique from those pages so that host has the option
-to service the request on the TVM synchronously or asynchronously.
-
-Both sharing and unsharing operations are destructive, i.e., the contents of
-memory in the range to be converted are lost.
+For `sbi_covg_unshare_memory_region()` to succeed in the guest, the host must
+first remove the shared pages from the guest with
+`sbi_covh_remove_shared_pages()`.
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
 [title= "TSM Detection and TVM creation"]
@@ -1251,6 +1175,8 @@ measurement is committed
 via this operation. No additional measured pages may be added after this
 operation is successfully completed.
 
+*VCPU transitions:* all TVM's vCPUs: VCPU_INITIALIZING -> VCPU_RUNNABLE(flush)
+
 The possible error codes returned in `sbiret.error` are shown below.
 
 [#table_sbi_covh_finalize_tvm_errors]
@@ -1313,6 +1239,8 @@ VM's data and the page tables. After this call, the OS/VMM must interact with
 this TVM via the TSM using the COVH ABI, i.e., resuming the TVM using the
 `sbi_covh_run_tvm_vcpu()` call.
 
+All vCPUs are created in VCPU_RUNNABLE(flush) state.
+
 *HPA transitions:*
 pages referenced by hgatp leaves: UNASSIGNED -> TVM(tvm_guest_id);
 other pages: UNASSIGNED -> TSM(tvm_guest_id)
@@ -1356,7 +1284,7 @@ The possible error codes returned in `sbiret.error` are shown below.
 *HPA transitions:*
 TVM(tvm_guest_id) -> UNASSIGNED;
 TSM(tvm_guest_id) -> UNASSIGNED;
-SHARED(tvm_guest_id) -> VMM
+MUTUAL(tvm_guest_id) -> VMM
 
 [#table_sbi_covh_destroy_tvm_errors]
 .COVE Host Destroy TVM Errors
@@ -1464,7 +1392,7 @@ will fail and the TVM will not be considered trustworthy by the relying party.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
-*HPA transitions:* source_address: VMM; dest_address: UNASSIGNED -> TVM(tvm_guest_id)
+*HPA transitions:* source_address: VMM -> VMM; dest_address: UNASSIGNED -> TVM(tvm_guest_id)
 
 *GPA transitions:* tvm_guest_gpa: MAPPABLE -> MAPPED
 
@@ -1543,7 +1471,7 @@ Shared pages can be added only after the TVM begins execution, and calls the
 TSM to define the location of shared memory regions. They are typically demand
 faulted on TVM access.
 
-*HPA transitions:* base_page_address: VMM -> SHARED(tvm_guest_id)
+*HPA transitions:* base_page_address: VMM -> MUTUAL(tvm_guest_id)
 
 *GPA transitions:* tvm_base_page_address: SHAREABLE -> SHARED
 
@@ -1573,10 +1501,25 @@ struct sbiret sbi_covh_create_tvm_vcpu(unsigned long tvm_guest_id,
 Adds a vCPU with ID `vcpu_id` to the TVM specified by `tvm_guest_id`.
 `tvm_state_page_addr` must be page-aligned and point to a confidential memory
 region used to hold the TVM's vCPU state, and must be
-`tsm_info::tvm_state_pages` pages in length. This call must not be made after
-calling `sbi_covh_finalize_tvm()`.
+`tsm_info::tvm_state_pages` pages in length.
+This call requires the TVM tvm_guest_id in TVM_INITIALIZING state.
 
 *HPA transitions:* tvm_state_page_addr: UNASSIGNED -> TSM(tvm_guest_id)
+
+*TVM transitions:* TVM_INITIALIZING -> TVM_INITIALIZING
+
+The vCPU is created in VCPU_INITIALIZING state.
+
+[#table_sbi_vcpu_states]
+.COVE vCPU States
+[cols="2,3", width=90%, align="center", options="header"]
+|===
+| State              | Description
+| VCPU_INITIALIZING       | The TVM has not been finalized.
+| VCPU_RUNNABLE()         | The vCPU can be run with sbi_covh_run_tvm_vcpu().
+| VCPU_RUNNABLE(flush)    | Ditto, and TSM must flush the TLB on sbi_covh_run_tvm_vcpu().
+| VCPU_RUNNING            | The vCPU is currently in sbi_covh_run_tvm_vcpu()
+|===
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -1603,6 +1546,17 @@ Runs the vCPU specified by `tvm_vcpu_id` in the TVM specified by `tvm_guest_id`.
 The `tvm_guest_id` must be in a "runnable" state (requires a prior call
 to `sbi_covh_finalize_tvm()`). The function does not return unless the TVM
 exits with a trap that cannot be handled by the TSM.
+
+The vCPU must be in a RUNNABLE state when, the ecall switches the VCPU to
+RUNNING state before executing the VCPU and back to RUNNABLE afterwards.
+
+*VCPU transitions:* RUNNABLE -> RUNNING -> RUNNABLE
+
+The TSM must flush TLB before running the vCPU if the vCPU is in the
+RUNNABLE(flush) state.
+
+A vCPU cannot be executed more than once from different harts -- the transition
+to RUNNING state and back must happen under a TSM internal lock.
 
 *Returns* SBI_SUCCESS in sbiret.value if the TVM exited with a resumable vCPU
 interrupt or exception, and non-zero otherwise. In the latter case, attempts to
@@ -1714,137 +1668,30 @@ enum Exception {
 };
 -------
 
-[#sbi_covh_tvm_fence]
-=== Function: COVE Host Initiate TVM Fence (FID #16)
-[source, C]
------
-struct sbiret sbi_covh_tvm_fence(unsigned long tvm_guest_id);
------
-Initiates a TLB invalidation sequence for all pages that have been invalidated
-in the given TVM's address space since the previous call to
-`sbi_covh_tvm_fence()`. The TLB invalidation sequence is completed when all
-vCPUs in the TVM that were running prior to the call to `sbi_covh_tvm_fence()`
-have taken a trap into the TSM, which the host can cause by sending an IPI to
-the physical CPUs on which the TVM's vCPUs are running. Note that the physical
-CPUs don't have to necessarily perform anything on those IPIs. An error is
-returned if a TLB invalidation sequence is already in progress for the TVM.
-
-*GPA transitions:* upon completion of the sequence: forall x. INVALIDATING(x) -> INVALIDATED(x)
-
-The possible error codes returned in `sbiret.error` are shown below.
-
-[#table_sbi_covh_tvm_fence_errors]
-.COVE Host Initiate TVM Fence
-[cols="2,3", width=90%, align="center", options="header"]
-|===
-| Error code              | Description
-| SBI_SUCCESS             | The operation completed successfully.
-| SBI_ERR_ALREADY_STARTED | A fence operation is already in progress.
-| SBI_ERR_FAILED          | The operation failed for unknown reasons.
-|===
-
-[#sbi_covh_tvm_invalidate_pages]
-=== Function: COVE Host TVM Invalidate Pages (FID #17)
-[source, C]
------
-struct sbiret sbi_covh_tvm_invalidate_pages(unsigned long tvm_guest_id,
-                                            unsigned long gpa,
-                                            unsigned long length);
------
-
-Invalidates the pages in the specified range of guest physical address space
-and thus marks the
-pages as blocked from any further TVM accesses.
-
-For each page in the range, the TSM must verify that:
-
-* The page is currently marked present in the TVM’s page table.
-* The page is either mapped and uniquely owned by the TVM, or shared and owned
-by the host.
-
-After verifying these pre-conditions are met, the TSM then invalidates the
-pages. The host must complete a TVM TLB invalidation sequence, initiated by
-`sbi_covh_tvm_fence()`, in order to complete the invalidation.
-
-Guest page faults taken by the TVM on invalidated pages continue to be reported
-to the host.
-The pages remain invalid until the mappings are validated (marked present),
-removed, or become part of a huge page by promotion/demotion operation.
-
-*GPA transitions:* gpa: SHARED -> INVALIDATING(SHARED) or MAPPED -> INVALIDATING(MAPPED)
-or MAPPED_SHAREABLE -> INVALIDATING(MAPPED_SHAREABLE) or UNSHARED -> INVALIDATING(UNSHARED)
-
-The possible error codes returned in `sbiret.error` are shown below.
-
-[#table_sbi_covh_tvm_invalidate_pages_errors]
-.COVE Host TVM Invalidate Pages
-[cols="2,3", width=90%, align="center", options="header"]
-|===
-| Error code              | Description
-| SBI_SUCCESS             | The operation completed successfully.
-| SBI_ERR_INVALID_PARAM   | `tvm_guest_id` or `length` were invalid.
-| SBI_ERR_INVALID_ADDRESS | `gpa` was invalid.
-| SBI_ERR_FAILED          | The operation failed for unknown reasons.
-|===
-
-[#sbi_covh_tvm_validate_pages]
-=== Function: COVE Host TVM Validate Pages (FID #18)
-[source, C]
------
-struct sbiret sbi_covh_tvm_validate_pages(unsigned long tvm_guest_id,
-                                          unsigned long gpa,
-                                          unsigned long length);
------
-
-Marks the invalidated pages in the specified range of guest physical address
-space as present.
-
-For each page in the range, the TSM must verify that the page was previously
-invalidated using `sbi_covh_tvm_invalidate_pages()`. After verifying the TSM
-will mark the pages as present and restore the pages to their previous state.
-
-This ECALL may be used to revert an in-progress page removal or huge page
-promotion/demotion sequence.
-
-*GPA transitions:* gpa: forall x. INVALIDATING(x) -> x or INVALIDATED(x) -> x
-
-The possible error codes returned in `sbiret.error` are shown below.
-
-[#table_sbi_covh_tvm_validate_pages_errors]
-.COVE Host TVM Validate Pages
-[cols="2,3", width=90%, align="center", options="header"]
-|===
-| Error code              | Description
-| SBI_SUCCESS             | The operation completed successfully.
-| SBI_ERR_INVALID_PARAM   | `tvm_guest_id` or `length` were invalid.
-| SBI_ERR_INVALID_ADDRESS | `gpa` was invalid.
-| SBI_ERR_FAILED          | The operation failed for unknown reasons.
-|===
-
-[#sbi_covh_tvm_remove_pages]
+[#sbi_covh_remove_tvm_shared_pages]
 === Function: COVE Host TVM Remove Pages (FID #19)
 [source, C]
 -----
-struct sbiret sbi_covh_tvm_remove_pages(unsigned long tvm_guest_id,
+struct sbiret sbi_covh_remove_tvm_shared_pages(unsigned long tvm_guest_id,
                                            unsigned long gpa,
                                            unsigned long length);
 -----
 
-Removes mappings for invalidated pages in the specified range of guest physical
-address space. The range to be unmapped must already have been invalidated and
-fenced, and must lie within a removable region of the guest's physical address
-space. The TSM zeros out all page table entries (PTEs) within the specified
-range. Confidential pages removed from the TVM return to the confidential
-`UNASSIGNED` pool; invalidated shared pages return to `VMM`.
+Removes mappings for shared pages in the specified range of guest physical
+address space.  All vCPUs of the TVM tvm_guest_id must be in a RUNNABLE state.
 
-*HPA transitions:* backing page for gpa: TVM(tvm_guest_id) -> UNASSIGNED or SHARED(tvm_guest_id) -> VMM
+*HPA transitions:* backing page for gpa: MUTUAL(tvm_guest_id) -> VMM
 
-*GPA transitions:* gpa: INVALIDATED(UNSHARED) -> MAPPABLE or INVALIDATED(MAPPED_SHAREABLE) -> SHAREABLE
-or INVALIDATED(MAPPED) -> MAPPABLE or INVALIDATED(SHARED) -> SHAREABLE
+*GPA transitions:* gpa: SHARED -> SHAREABLE
+
+*VCPU transitions:* all TVM's vcpus: RUNNABLE(...) -> RUNNABLE(flush)
+
+NOTE: the TSM must flush the VCPU TLB upon switching the VCPU state from
+RUNNABLE(flush) to RUNNING
 
 The possible error codes returned in `sbiret.error` are shown below.
 
-[#table_sbi_covh_tvm_remove_pages_errors]
+[#table_sbi_covh_remove_tvm_shared_pages_errors]
 .COVE Host TVM Remove Pages
 [cols="2,3", width=90%, align="center", options="header"]
 |===
@@ -2276,34 +2123,15 @@ struct sbiret sbi_covg_share_memory_region(unsigned long tvm_gpa_addr,
 Initiates the assignment-change of TVM physical address space starting at
 `tvm_gpa_addr` from confidential to non-confidential/shared memory. The
 requested range must lie within an existing region of confidential address
-space, and may or may not be populated. This ECALL results in an exit to the TSM
-which enforces the security properties on the mapping and exits to the VMM
-host. The host then removes any confidential pages already populated in the
-region and inserts non-confidential pages on page-faults. For populated ranges,
-the host must invalidate the confidential mappings, complete `sbi_covh_tvm_fence()`,
-and then remove the pages with `sbi_covh_tvm_remove_pages()` before shared
-pages may be inserted.
+space, and may or may not be populated.
 
-The calling TVM vCPU is considered blocked until the assignment-change is
-completed. Attempts to run it with `sbi_covh_run_tvm_vcpu()` will fail. Any
-guest page faults taken by other TVM vCPUs in the invalidated pages continue to
-be reported to the host.
-
-In CoVE implementations that do not support dynamic page conversion between
-confidential and non-confidential memory, the TSM reflects this call to the
-OS/VMM, which then allocates contiguous non-confidential pages and returns the
-host physical address of the first page to the TSM. The TSM maps the
-non-confidential pages to the TVM's address space.
-
-In systems with fragmented memory and lack of dynamic page conversion,
-the OS/VMM may fail allocating a single large physical memory region that
-spans over contiguous non-confidential pages. The TVM should then retry and
-request share of multiple smaller memory regions, for example, at the 4 KiB page
-size granularity.
+The TSM removes any confidential pages already populated in the region.
 
 Both `tvm_gpa_addr` and `region_len` must be 4 KiB-aligned.
 
-*GPA transitions:* tvm_gpa_addr: MAPPABLE -> SHAREABLE or MAPPED -> MAPPED_SHAREABLE
+*GPA transitions:* tvm_gpa_addr: MAPPABLE -> SHAREABLE or MAPPED -> SHAREABLE
+
+*HPA transitions:* when GPA transitions MAPPED -> SHAREABLE: TVM(gid) -> UNMAPPED
 
 The possible error codes returned in sbiret.error are:
 
@@ -2330,25 +2158,17 @@ struct sbiret sbi_covg_unshare_memory_region(unsigned long tvm_gpa_addr,
 -------
 Initiates the assignment-change of TVM physical address space starting at
 `tvm_gpa_addr` from
-shared to confidential. The requested range must lie within an existing region
-of non-confidential
-address space, and may or may not be populated. This ECALL results in an exit
-to the TSM which
-enforces the security properties on the mapping and exits to the OS/VMM. The
-host then removes
-any non-confidential pages already populated in the region and inserts
-confidential pages on page-faults. For populated ranges, the host must
-invalidate the shared mappings, complete `sbi_covh_tvm_fence()`, and then
-remove the pages with `sbi_covh_tvm_remove_pages()` before confidential pages
-may be inserted.
+shared to confidential. The requested range must lie within an existing SHARED
+or SHAREABLE address space, and must not be populated.
 
-The calling TVM vCPU is considered blocked until the assignment-change is
-completed. Attempts to run it
-with `sbi_covh_run_tvm_vcpu()` will fail. Any guest page faults taken by other
-TVM vCPUs in the
-invalidated pages continue to be reported to the host.
+NOTE: Since the pages in the unshared range must have been unmapped, there is
+no need to flush TLB for the TVM nor the VMM.
 
-*GPA transitions:* tvm_gpa_addr: SHARED -> UNSHARED, SHAREABLE -> MAPPABLE, MAPPED_SHAREABLE -> MAPPED
+NOTE: We could have just as well allowed the range to be populated with
+non-MUTUAL(gid) (confidential) pages, but we didn't find any use cases that it
+would significantly simplify.
+
+*GPA transitions:* tvm_gpa_addr: SHAREABLE -> MAPPABLE
 
 Both `tvm_gpa_addr` and `region_len` must be 4 KiB-aligned.
 
@@ -2358,8 +2178,6 @@ Both `tvm_gpa_addr` and `region_len` must be 4 KiB-aligned.
 |===
 | Error code              | Description
 | SBI_SUCCESS             | The operation completed successfully.
-                            This implies an exit to the host, and a subsequent
-resume of execution.
 | SBI_ERR_INVALID_ADDRESS | `tvm_gpa_addr` was invalid.
 | SBI_ERR_INVALID_PARAM   | `region_len` was invalid, or the entire range
 doesn't
@@ -2817,58 +2635,9 @@ that is assigned to the TVM and one that is not already active. The TSM
 verifies if the operation is performed in the right state for that
 virtual hart.
 
-| <<sbi_covh_tvm_fence, sbi_covh_tvm_fence>> | Initiates a TLB invalidation
-sequence for all pages that have been invalidated in the given TVM's address
-space
-since the previous call to `sbi_covh_tvm_fence()`. The TLB invalidation
-sequence is
-completed when all vCPUs in the TVM that were running before the call to
-`sbi_covh_tvm_fence()` have taken a trap into the TSM, which the host can
-cause by sending an IPI to the physical CPUs on which the TVM's vCPUs are
-running.
-
-| <<sbi_covh_tvm_invalidate_pages, sbi_covh_tvm_invalidate_pages>> |
-Invalidates the pages in the specified range of guest physical address space
-and thus marks the
-pages as blocked from any further TVM accesses. Guest page faults taken by the
-TVM on invalidated
-pages continue to be reported to the host. The page remains invalid until the
-mapping is validated
-(marked present), removed, or becomes part of a huge page by promotion/demotion
-operation.
-
-| <<sbi_covh_tvm_validate_pages, sbi_covh_tvm_validate_pages>> |
-Marks the invalidated pages in the specified range of guest physical address
-space
-as present. This ECALL may also be used to revert an in-progress page removal or
-huge page promotion/demotion sequence.
-
-| <<sbi_covh_tvm_remove_pages, sbi_covh_tvm_remove_pages>> |
-Removes mappings for invalidated pages in the specified range of guest physical
+| <<sbi_covh_remove_tvm_shared_pages, sbi_covh_remove_tvm_shared_pages>> |
+Removes mappings for shared pages in the specified range of guest physical
 address space.
-The range to be unmapped must already have been invalidated and fenced, and
-must lie within a
-removable region of the guest's physical address space.
-
-| sbi_covh_page_relocate                     | Relocate a page for an
-existing mapping for a TVM page. This operation allows the VMM to reassign
-a new SPA for an existing TVM page mapping. The page mapping must be
-invalid and fenced before the page mapping can be
-relocated. This interface specification is TBD.
-
-| sbi_covh_page_promote                      | Promote a set of small
-page mappings (existing mappings) for a set of TVM pages to a large page
-mapping. The affected mappings must be invalidated before the promote operation
-can succeed. The VMM may reclaim the freed G-stage page table page if
-the operation succeeds. This interface specification is TBD for version 2 of
-the ABI.
-
-| sbi_covh_page_demote                    | Demote a large page
-mapping for an existing mapping to a set of TVM pages and corresponding
-small page mappings. The affected mapping must be invalidated before the
-operation can succeed. The VMM must provide a free Confidential memory page to
-the TSM to use as a new G-stage page table in the fragmented mapping.
-This interface specification is TBD for version 2 of the ABI.
 
 |===
 

--- a/src/swlifecycle.adoc
+++ b/src/swlifecycle.adoc
@@ -241,46 +241,6 @@ is for example for untrusted IO.
 . Access to shared memory pages must be explicitly signaled by the TVM via
 the GPA and enforced for memory access for the TVM by the hardware.
 
-====  Information tracked per physical page
-
-For implementations that utilize MTT, the Extended Memory Tracking Table (EMTT)
-information managed by the TSM
-is used to track additional fields of metadata associated with physical
-addresses.
-The page size is implicit in the MTT and EMTT lookup - 4 KiB, 2 MiB, 1 GiB, 512 GiB.
-Actual page sizes supported are implementation-specified.
-
-|===
-h| Memory Type h| Confidential or Non-confidential (enforced via MTT)
-| Page-Type
-a| Reserved - page that may not be assigned to any TEE entity.
-
-If the Memory Type is Confidential, the following page types may be used:
-
-* Unassigned - page not assigned to any TEE (TSM or TVM)
-* TVM - page assigned to a TVM (mapped via G-stage page table)
-* TSM - page used by the TSM (for MTT and other control structures)
-| Page Owner  | If the Memory Type is Confidential and Page-Type is TVM,
-this value holds the identifier (e.g., PPN) for the TVM control page (4 KiB TEE-
-TSM-TVM page); else it is 0.
-| Page sub-type a| Following types apply if Memory Type is Confidential and
-Page-Type is TVM:
-
-* HGATP - pages used for HGATP structures
-* Data - pages used for TVM content
-
-Following types apply if Memory Type is Confidential and Page-Type is TSM:
-
-* MTT - pages used for MTT structures
-* TVMC - pages used for TVM control structure(s) for global control
-* VHCS - pages used for TVM VHCS (virtual hart control structures)
-| Page TLB version | TLB version in which the page mapping was invalidated to
-allow for VMM memory management. If the page is Unassigned, the TLB version is
-per the global TLB management. If the page is assigned to a TVM, it is versioned
-per the TVM-local TLB management.
-| Additional meta-data | Locking state
-|===
-
 ==== Page walk and Translation caching considerations
 
 Any caching of the address translation information when the memory tracking for
@@ -754,4 +714,3 @@ RAS-induced access violations on a TVM lead to TSM-enforced TVM shutdown and are
 reported to the OS/VMM for further analysis (without allowing any TVM access).
 Similarly, RAS-interrupts (both high and low priority) are forwarded by the TSM
 to the OS/VMM for handling.
-


### PR DESCRIPTION
Replace the EMTT by explicit memory tracking state machines that are integrated as pre-conditions and post-conditions to the ecalls.

The HPA diagram renders as:
<img width="2552" height="1011" alt="image" src="https://github.com/user-attachments/assets/2a00e8c9-dba4-40fc-a917-9e99616f91eb" />

The GPA state machine is (I think unnecessarily) complicated because of the invalidation protocol, and it already forbade some flows like interleaving of host side invalidation and guest side sharing/unsharing.

The GPA diagram renders as:
<img width="1196" height="1027" alt="image" src="https://github.com/user-attachments/assets/e3c8765c-6e07-46ba-84a3-1fdbf3963147" />
